### PR TITLE
conda: add libgdf_cffi to notebook env

### DIFF
--- a/conda_environments/notebook_py35.yml
+++ b/conda_environments/notebook_py35.yml
@@ -3,6 +3,8 @@ channels:
 - !!python/unicode
   'numba'
 - !!python/unicode
+  'gpuopenanalytics/label/dev'
+- !!python/unicode
   'defaults'
 dependencies:
 - !!python/unicode
@@ -153,6 +155,8 @@ dependencies:
   'llvmlite=0.18'
 - !!python/unicode
   'numba=0.33'
+- !!python/unicode
+  'libgdf_cffi=0.1.0a1.dev'
 - pip:
   - flatbuffers==2015.12.22.1
   - ipython-genutils==0.2.0


### PR DESCRIPTION
The [demo](https://github.com/gpuopenanalytics/demo-docker.git) uses the notebook env, which doesn't have `libgdf_cffi`. This results in 

```
ImportError: No module named 'libgdf_cffi'
```