### PR TITLE
Implicit cast integral dtype to float dtype for stats functions

### DIFF
--- a/pygdf/numerical.py
+++ b/pygdf/numerical.py
@@ -116,6 +116,12 @@ class Stats(object):
     def __init__(self, series):
         self._series = series
 
+    def _ensure_real_dtype(self):
+        series = self._series
+        if issubclass(self._series.dtype.type, np.integer):
+            series = series.astype(np.float64)
+        return series
+
     def min(self):
         return _gdf.apply_reduce(libgdf.gdf_min_generic, self._series)
 
@@ -123,12 +129,15 @@ class Stats(object):
         return _gdf.apply_reduce(libgdf.gdf_max_generic, self._series)
 
     def mean(self):
-        asum = _gdf.apply_reduce(libgdf.gdf_sum_generic, self._series)
+
+        asum = _gdf.apply_reduce(libgdf.gdf_sum_generic,
+                                 self._ensure_real_dtype())
         return asum / len(self._series)
 
     def mean_var(self):
         mu = self.mean()
         n = len(self._series)
-        asum = _gdf.apply_reduce(libgdf.gdf_sum_squared_generic, self._series)
+        asum = _gdf.apply_reduce(libgdf.gdf_sum_squared_generic,
+                                 self._ensure_real_dtype())
         var = asum / n - mu ** 2
         return mu, var

--- a/pygdf/tests/test_stats.py
+++ b/pygdf/tests/test_stats.py
@@ -19,20 +19,26 @@ def test_series_max():
     np.testing.assert_almost_equal(arr.max(), sr.max())
 
 
-def test_series_mean():
-    arr = np.random.random(100)
+params_dtypes = [np.int32, np.float32, np.float64]
+
+
+@pytest.mark.parametrize('dtype', params_dtypes)
+def test_series_mean(dtype):
+    arr = np.random.random(100).astype(dtype)
     sr = Series.from_any(arr)
     np.testing.assert_almost_equal(arr.mean(), sr.mean())
 
 
-def test_series_var():
-    arr = np.random.random(100)
+@pytest.mark.parametrize('dtype', params_dtypes)
+def test_series_var(dtype):
+    arr = np.random.random(100).astype(dtype)
     sr = Series.from_any(arr)
     np.testing.assert_almost_equal(arr.var(), sr.var())
 
 
-def test_series_std():
-    arr = np.random.random(100)
+@pytest.mark.parametrize('dtype', params_dtypes)
+def test_series_std(dtype):
+    arr = np.random.random(100).astype(dtype)
     sr = Series.from_any(arr)
     np.testing.assert_almost_equal(arr.std(), sr.std())
 


### PR DESCRIPTION
Fix https://github.com/gpuopenanalytics/demo-docker/issues/7
This introduces a inefficient typecast when the Series dtype is integral.
TODO add a specialized version to avoid the extra .astype().