### PR TITLE
Add support for concat

### DIFF
--- a/pygdf/__init__.py
+++ b/pygdf/__init__.py
@@ -1,5 +1,6 @@
 from .dataframe import DataFrame
 from .series import Series
+from .multi import concat
 
 from .settings import set_options
 

--- a/pygdf/categorical.py
+++ b/pygdf/categorical.py
@@ -116,6 +116,3 @@ class CategoricalSeriesImpl(series_impl.SeriesImpl):
                                          categories=self._categories,
                                          ordered=self._ordered)
         return pd.Series(data, index=index)
-
-    def concat(self, objs):
-        return self._codes_impl.concat(objs)

--- a/pygdf/categorical.py
+++ b/pygdf/categorical.py
@@ -46,14 +46,11 @@ class CategoricalSeriesImpl(series_impl.SeriesImpl):
         self._codes_impl = numerical.NumericalSeriesImpl(codes_dtype)
 
     def __eq__(self, other):
-        try:
-            return (isinstance(other, CategoricalSeriesImpl) and
-                    self.dtype == other.dtype and
-                    tuple(self._categories) == tuple(other._categories) and
-                    self._ordered == other._ordered and
-                    self._codes_impl == other._codes_impl)
-        except Exception:
-            return False
+        return (isinstance(other, CategoricalSeriesImpl) and
+                self.dtype == other.dtype and
+                tuple(self._categories) == tuple(other._categories) and
+                self._ordered == other._ordered and
+                self._codes_impl == other._codes_impl)
 
     def _encode(self, value):
         for i, cat in enumerate(self._categories):

--- a/pygdf/categorical.py
+++ b/pygdf/categorical.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pandas as pd
 
 from .dataframe import Series
@@ -47,11 +46,14 @@ class CategoricalSeriesImpl(series_impl.SeriesImpl):
         self._codes_impl = numerical.NumericalSeriesImpl(codes_dtype)
 
     def __eq__(self, other):
-        if isinstance(other, CategoricalSeriesImpl):
-            return all([self.dtype == other.dtype,
-                        tuple(self._categories) == tuple(other._categories),
-                        self._ordered == other._ordered,
-                        self._codes_impl == other._codes_impl])
+        try:
+            return (isinstance(other, CategoricalSeriesImpl) and
+                    self.dtype == other.dtype and
+                    tuple(self._categories) == tuple(other._categories) and
+                    self._ordered == other._ordered and
+                    self._codes_impl == other._codes_impl)
+        except Exception:
+            return False
 
     def _encode(self, value):
         for i, cat in enumerate(self._categories):
@@ -110,8 +112,13 @@ class CategoricalSeriesImpl(series_impl.SeriesImpl):
     def as_index(self, series):
         return self._codes_impl.as_index(series)
 
-    def to_pandas(self, series):
-        values = list(series)
-        return pd.Categorical(values, categories=self._categories,
-                              ordered=self._ordered)
+    def to_pandas(self, series, index=True):
+        if index is True:
+            index = series.index.to_pandas()
+        data = pd.Categorical.from_codes(series.cat.codes.to_array(),
+                                         categories=self._categories,
+                                         ordered=self._ordered)
+        return pd.Series(data, index=index)
 
+    def concat(self, objs):
+        return self._codes_impl.concat(objs)

--- a/pygdf/multi.py
+++ b/pygdf/multi.py
@@ -1,0 +1,37 @@
+from .dataframe import DataFrame
+from .series import Series
+from .index import Index
+
+
+def concat(objs):
+    """Concatenate DataFrames, Series, or Indices row-wise.
+
+    Parameters
+    ----------
+    objs : list of DataFrame, Series, or Index
+
+    Returns
+    -------
+    A new object of like type with rows from each object in ``objs``.
+    """
+    if not objs:
+        raise ValueError("Need at least one object to concatenate")
+
+    # no-op for single object
+    if len(objs) == 1:
+        return objs[0]
+
+    typs = set(type(o) for o in objs)
+    if len(typs) > 1:
+        raise ValueError("`concat` expects all objects to be of the same "
+                         "type. Got mix of %r." % [t.__name__ for t in typs])
+    typ = list(typs)[0]
+
+    if typ is DataFrame:
+        return DataFrame._concat(objs)
+    elif typ is Series:
+        return Series._concat(objs)
+    elif issubclass(typ, Index):
+        return Index._concat(objs)
+    else:
+        raise ValueError("Unknown type %r" % typ)

--- a/pygdf/numerical.py
+++ b/pygdf/numerical.py
@@ -2,12 +2,10 @@ from __future__ import print_function, division
 
 import numpy as np
 import pandas as pd
-from numba import cuda
 
 from libgdf_cffi import libgdf
 
 from . import _gdf, series_impl, utils, cudautils
-from .buffer import Buffer
 
 
 # Operator mappings
@@ -99,15 +97,6 @@ class NumericalSeriesImpl(series_impl.SeriesImpl):
         if index is True:
             index = series.index.to_pandas()
         return pd.Series(series.to_array(fillna='pandas'), index=index)
-
-    def concat(self, objs):
-        newsize = sum(map(len, objs))
-        # Concatenate data
-        mem = cuda.device_array(shape=newsize, dtype=self.dtype)
-        data = Buffer.from_empty(mem)
-        for o in objs:
-            data.extend(o._data.to_gpu_array())
-        return data
 
     #
     # Internals

--- a/pygdf/series.py
+++ b/pygdf/series.py
@@ -419,12 +419,16 @@ class Series(object):
             if o._impl != head._impl:
                 raise ValueError("All series must be of same type")
 
-        data = head._impl.concat(objs)
+        newsize = sum(map(len, objs))
+        # Concatenate data
+        mem = cuda.device_array(shape=newsize, dtype=head._data.dtype)
+        data = Buffer.from_empty(mem)
+        for o in objs:
+            data.extend(o._data.to_gpu_array())
 
         # Concatenate mask if present
         if all(o.has_null_mask for o in objs):
             # FIXME: Inefficient
-            newsize = sum(map(len, objs))
             mem = cuda.device_array(shape=newsize, dtype=np.bool)
             mask = Buffer.from_empty(mem)
             null_count = 0

--- a/pygdf/series_impl.py
+++ b/pygdf/series_impl.py
@@ -18,13 +18,13 @@ class SeriesImpl(object):
         self._dtype = dtype
 
     def __eq__(self, other):
-        return self.dtype == other.dtype
+        try:
+            return self.dtype == other.dtype
+        except Exception:
+            return False
 
     def __ne__(self, other):
-        out = self.dtype == other.dtype
-        if out is NotImplemented:
-            return out
-        return not out
+        return not self == other
 
     @property
     def dtype(self):

--- a/pygdf/tests/test_dataframe.py
+++ b/pygdf/tests/test_dataframe.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 from numba import cuda
 
+import pygdf as gd
 from pygdf.dataframe import Series, DataFrame
 from pygdf.buffer import Buffer
 from pygdf.settings import set_options
@@ -124,7 +125,7 @@ def test_dataframe_basic():
     df2['vals'] = np.array([321], dtype=np.float64)
 
     # Concat
-    df = df.concat(df2)
+    df = gd.concat([df, df2])
     assert len(df) == 11
 
     hkeys = np.asarray(np.arange(10, dtype=np.float64).tolist() + [123])

--- a/pygdf/tests/test_multi.py
+++ b/pygdf/tests/test_multi.py
@@ -1,0 +1,76 @@
+import pytest
+
+import pandas as pd
+import pygdf as gd
+
+
+def make_frames(index=None):
+    df = pd.DataFrame({'x': range(10),
+                       'y': list(map(float, range(10))),
+                       'z': list('abcde')*2})
+    df.z = df.z.astype('category')
+    df2 = pd.DataFrame({'x': range(10, 20),
+                        'y': list(map(float, range(10, 20))),
+                        'z': list('edcba')*2})
+    df2.z = df2.z.astype('category')
+    gdf = gd.DataFrame.from_pandas(df)
+    gdf2 = gd.DataFrame.from_pandas(df2)
+    if index:
+        df = df.set_index(index)
+        df2 = df2.set_index(index)
+        gdf = gdf.set_index(index)
+        gdf2 = gdf2.set_index(index)
+    return df, df2, gdf, gdf2
+
+
+@pytest.mark.parametrize('index', [False, 'z', 'y'])
+def test_concat(index):
+    df, df2, gdf, gdf2 = make_frames(index)
+
+    # DataFrame
+    res = gd.concat([gdf, gdf2, gdf]).to_pandas()
+    sol = pd.concat([df, df2, df])
+    pd.util.testing.assert_frame_equal(res, sol, check_names=False)
+
+    # Series
+    for c in [i for i in ('x', 'y', 'z') if i != index]:
+        res = gd.concat([gdf[c], gdf2[c], gdf[c]]).to_pandas()
+        sol = pd.concat([df[c], df2[c], df[c]])
+        pd.util.testing.assert_series_equal(res, sol, check_names=False)
+
+    # Index
+    res = gd.concat([gdf.index, gdf2.index]).to_pandas()
+    sol = df.index.append(df2.index)
+    pd.util.testing.assert_index_equal(res, sol, check_names=False)
+
+
+def test_concat_errors():
+    df, df2, gdf, gdf2 = make_frames()
+
+    # No objs
+    with pytest.raises(ValueError):
+        gd.concat([])
+
+    # Mismatched types
+    with pytest.raises(ValueError):
+        gd.concat([gdf, gdf.x])
+
+    # Unknown type
+    with pytest.raises(ValueError):
+        gd.concat(['bar', 'foo'])
+
+    # Mismatched column dtypes
+    with pytest.raises(ValueError):
+        gd.concat([gdf.x, gdf.y])
+    with pytest.raises(ValueError):
+        gd.concat([gdf.x, gdf.z])
+
+    # Mismatched index dtypes
+    gdf3 = gdf2.set_index('z')
+    gdf2.drop_column('z')
+    with pytest.raises(ValueError):
+        gd.concat([gdf2, gdf3])
+
+    # Mismatched columns
+    with pytest.raises(ValueError):
+        gd.concat([gdf, gdf2])


### PR DESCRIPTION
- Add a top-level `concat` function for concatenating dataframes,
  series, or indices together
- Remove old `concat` method, as it didn't match pandas api
- Fix bugs in `to_pandas` implementation to properly handle indices