### PR TITLE
unique_k returns a series

### DIFF
--- a/pygdf/cudautils.py
+++ b/pygdf/cudautils.py
@@ -532,7 +532,7 @@ class UniqueBySorting(object):
             end = min(qsz, self._maxk)
         else:
             raise NotImplementedError('k is unbounded')
-        vals = out_queue[:end].copy_to_host()
+        vals = out_queue[:end]
         return vals
 
     def run(self, arr):

--- a/pygdf/series.py
+++ b/pygdf/series.py
@@ -767,7 +767,8 @@ class Series(object):
         if self.null_count == len(self):
             return np.empty(0, dtype=self.dtype)
         arr = self.to_dense_buffer().to_gpu_array()
-        return cudautils.compute_unique_k(arr, k=k)
+        res = cudautils.compute_unique_k(arr, k=k)
+        return Series.from_array(res)
 
     def scale(self):
         """Scale values to [0, 1] in float64

--- a/pygdf/tests/test_stats.py
+++ b/pygdf/tests/test_stats.py
@@ -27,7 +27,7 @@ def test_series_unique():
         arr = np.random.randint(low=-1, high=10, size=size)
         mask = arr != -1
         sr = Series.from_masked_array(arr, Series(mask).as_mask())
-        assert set(arr[mask]) == set(sr.unique_k(k=10))
+        assert set(arr[mask]) == set(sr.unique_k(k=10).to_array())
     # test out of space
     arr = np.arange(10)
     sr = Series.from_any(arr)


### PR DESCRIPTION
Previously `Series.unique_k` returned a numpy array. We now return a
`pygdf.Series` instead.

Fixes #51.