### PR TITLE
Fix invalid dtype due to Series.astype

### DIFF
--- a/pygdf/numerical.py
+++ b/pygdf/numerical.py
@@ -91,7 +91,7 @@ class NumericalColumn(columnops.TypedColumnBase):
             return self
         else:
             col = self.replace(data=self.data.astype(dtype),
-                               dtype=dtype)
+                               dtype=np.dtype(dtype))
             return col
 
     def sort_by_values(self, ascending):

--- a/pygdf/tests/test_dataframe.py
+++ b/pygdf/tests/test_dataframe.py
@@ -162,9 +162,9 @@ def test_dataframe_astype():
     df = DataFrame()
     data = np.asarray(range(10), dtype=np.int32)
     df['a'] = data
-    assert df['a'].dtype == np.dtype(np.int32)
+    assert df['a'].dtype is np.dtype(np.int32)
     df['b'] = df['a'].astype(np.float32)
-    assert df['b'].dtype == np.dtype(np.float32)
+    assert df['b'].dtype is np.dtype(np.float32)
     np.testing.assert_equal(df['a'].to_array(), df['b'].to_array())
 
 


### PR DESCRIPTION
Problem: `.astype()` is setting the column dtype to a `dtype.type` instead of a `dtype`.