### PR TITLE
Fix #48: error due non-writeable broadcasted ndarray

### DIFF
--- a/pygdf/tests/test_binops.py
+++ b/pygdf/tests/test_binops.py
@@ -2,6 +2,7 @@ from __future__ import division
 
 import operator
 import random
+from itertools import product
 
 import pytest
 import numpy as np
@@ -48,9 +49,9 @@ def test_series_compare(cmpop):
     np.testing.assert_equal(cmpop(sr1, sr2).to_array(),  cmpop(arr1, arr2))
 
 
-@pytest.mark.parametrize('cmpop', _cmpops)
-def test_series_compare_scalar(cmpop):
-    arr1 = np.random.random(100)
+@pytest.mark.parametrize('nelem,cmpop', list(product([1, 2, 100], _cmpops)))
+def test_series_compare_scalar(nelem, cmpop):
+    arr1 = np.random.random(nelem)
     sr1 = Series(arr1)
     rhs = np.asscalar(random.choice(arr1))
     np.testing.assert_equal(cmpop(sr1, rhs).to_array(),  cmpop(arr1, rhs))

--- a/pygdf/utils.py
+++ b/pygdf/utils.py
@@ -42,13 +42,18 @@ def make_mask(size):
     return cuda.device_array(shape=size, dtype=mask_dtype)
 
 
+def require_writeable_array(arr):
+    # This should be fixed in numba (numba issue #2521)
+    return np.require(arr, requirements='W')
+
+
 def scalar_broadcast_to(scalar, shape, dtype):
     if not isinstance(shape, tuple):
         shape = (shape,)
     arr = np.broadcast_to(np.asarray(scalar, dtype=dtype), shape=shape)
     # FIXME: this is wasteful, but numba can't slice 0-strided array
-    arr = np.ascontiguousarray(arr)
-    return cuda.to_device(arr)
+    arr = np.ascontiguousarray(np.asarray(arr))
+    return cuda.to_device(require_writeable_array(arr))
 
 
 def normalize_index(index, size, doraise=True):


### PR DESCRIPTION
Add utils to force writeable of numpy array.
This should really be fixed in numba (https://github.com/numba/numba/issues/2521).