### PR TITLE
Fix #44: cat column use -1 for na.

### DIFF
--- a/pygdf/categorical.py
+++ b/pygdf/categorical.py
@@ -132,6 +132,9 @@ class CategoricalColumn(columnops.TypedColumnBase):
             if i == value:
                 return cat
 
+    def default_na_value(self):
+        return -1
+
 
 def pandas_categorical_as_column(categorical, codes=None):
     """Creates a CategoricalColumn from a pandas.Categorical

--- a/pygdf/column.py
+++ b/pygdf/column.py
@@ -323,12 +323,9 @@ class Column(object):
 
         if self.has_null_mask:
             if fillna == 'pandas':
-                # cast non-float types to float64
-                col = (self.astype(np.float64)
-                       if self.dtype.kind != 'f'
-                       else self)
+                na_value = self.default_na_value()
                 # fill nan
-                return col.fillna(np.nan)
+                return self.fillna(na_value)
             else:
                 return self._copy_to_dense_buffer()
         else:

--- a/pygdf/numerical.py
+++ b/pygdf/numerical.py
@@ -1,5 +1,7 @@
 from __future__ import print_function, division
 
+import numbers
+
 import numpy as np
 import pandas as pd
 
@@ -172,8 +174,17 @@ class NumericalColumn(columnops.TypedColumnBase):
         if out_dtype is None:
             out_dtype = self.dtype
         out = columnops.column_applymap(udf=udf, column=self,
-                                         out_dtype=out_dtype)
+                                        out_dtype=out_dtype)
         return self.replace(data=out)
+
+    def default_na_value(self):
+        """Returns the default NA value for this column
+        """
+        dkind = self.dtype.kind
+        if dkind == 'f':
+            return np.nan
+        else:
+            raise TypeError("numeric column of {} has no NaN value".format(self.dtype))
 
 
 def numeric_column_binop(lhs, rhs, op, out_dtype):

--- a/pygdf/tests/test_categorical.py
+++ b/pygdf/tests/test_categorical.py
@@ -35,13 +35,17 @@ def test_categorical_missing():
     cat = pd.Categorical(['a', '_', '_', 'c', 'a'], categories=['a', 'b', 'c'])
     pdsr = pd.Series(cat)
     sr = Series(cat)
-    fillna = lambda x: np.where(np.isnan(x), -1, x)
-    np.testing.assert_array_equal(cat.codes, fillna(sr.to_array(fillna='pandas')))
+    np.testing.assert_array_equal(cat.codes, sr.to_array(fillna='pandas'))
     assert sr.null_count == 2
 
     np.testing.assert_array_equal(pdsr.cat.codes.data,
-                                  fillna(sr.cat.codes.to_array(fillna='pandas')))
+                                  sr.cat.codes.fillna(-1).to_array())
     np.testing.assert_equal(pdsr.cat.codes.dtype, sr.cat.codes.dtype)
+
+    # integer doesn't have nan value
+    with pytest.raises(TypeError) as raises:
+        sr.cat.codes.to_array(fillna='pandas')
+    raises.match('NaN value')
 
     string = str(sr)
     expect_str = """


### PR DESCRIPTION
* Add `default_na_value()` to column classes.
* Integeral numeric column raise on pandas-style fillna for a safer behavior.