### PR TITLE
Fix index of queried Series.

### DIFF
--- a/pygdf/index.py
+++ b/pygdf/index.py
@@ -12,9 +12,14 @@ from .column import Column
 class Index(object):
     def take(self, indices):
         assert indices.dtype.kind in 'iu'
-        index = cudautils.gather(data=self.gpu_values, index=indices)
-        col = self.as_column().replace(data=Buffer(index))
-        return GenericIndex(col)
+        if indices.size == 0:
+            # Empty indices
+            return RangeIndex(indices.size)
+        else:
+            # Gather
+            index = cudautils.gather(data=self.gpu_values, index=indices)
+            col = self.as_column().replace(data=Buffer(index))
+            return GenericIndex(col)
 
     def argsort(self, ascending=True):
         return self.as_column().argsort(ascending=ascending)

--- a/pygdf/series.py
+++ b/pygdf/series.py
@@ -131,8 +131,8 @@ class Series(object):
         if isinstance(arg, Series):
             selvals, selinds = columnops.column_select_by_boolmask(
                 self._column, arg)
-            return self._copy_construct(data=selvals,
-                                        index=GenericIndex(selinds))
+            index = self.index.take(selinds.to_gpu_array())
+            return self._copy_construct(data=selvals, index=index)
 
         elif isinstance(arg, slice):
             index = self.index[arg]         # slice index

--- a/pygdf/tests/test_query.py
+++ b/pygdf/tests/test_query.py
@@ -4,8 +4,11 @@ import inspect
 
 import pytest
 import numpy as np
+import pandas as pd
+from pandas.util.testing import assert_frame_equal
 from itertools import product
 
+import pygdf
 from pygdf import queryutils
 from pygdf.dataframe import DataFrame
 
@@ -94,4 +97,26 @@ def test_query_env_changing():
     c = 50
     got = df.query(expr)
     np.testing.assert_array_equal(aa[aa < c], got['a'].to_array())
+
+
+def test_query_splitted_combine():
+    np.random.seed(0)
+    df = pd.DataFrame({'x': np.random.randint(0, 5, size=10),
+                       'y': np.random.normal(size=10)})
+    gdf = DataFrame.from_pandas(df)
+
+    # Split the GDF
+    s1 = gdf[:5]
+    s2 = gdf[5:]
+
+    # Do the query
+    expr = 'x > 2'
+    q1 = s1.query(expr)
+    q2 = s2.query(expr)
+    # Combine
+    got = pygdf.concat([q1, q2]).to_pandas()
+
+    # Should equal to just querying the original GDF
+    expect = gdf.query(expr).to_pandas()
+    assert_frame_equal(got, expect)
 


### PR DESCRIPTION
**Problem**

The problem is revealed when the Series.index is not a simple range of 0..size-1.  ``Series.__getitem__(booleans)`` used the location as the result index instead of the "label".

**Fix**

``Series.__getitem__(booleans)`` should use ``index.take``.
