### PR TITLE
Make Dataframe pickle-able

### DIFF
--- a/pygdf/buffer.py
+++ b/pygdf/buffer.py
@@ -23,6 +23,12 @@ class Buffer(object):
         self.capacity = capacity
         self.dtype = self.mem.dtype
 
+    def __reduce__(self):
+        return type(self), (self.to_array(), self.size, self.capacity)
+
+    def __sizeof__(self):
+        return self.mem.alloc_size
+
     def __getitem__(self, arg):
         if isinstance(arg, slice):
             sliced = self.to_gpu_array()[arg]

--- a/pygdf/column.py
+++ b/pygdf/column.py
@@ -107,6 +107,12 @@ class Column(object):
 
         self._null_count = null_count
 
+    def __sizeof__(self):
+        n = self._data.__sizeof__()
+        if self._mask:
+            n += self._mask.__sizeof__()
+        return n
+
     def __len__(self):
         return self._data.size
 

--- a/pygdf/dataframe.py
+++ b/pygdf/dataframe.py
@@ -97,8 +97,9 @@ class DataFrame(object):
         return list(o)
 
     def __getattr__(self, key):
-        if key in self._cols:
+        if key != '_cols' and key in self._cols:
             return self[key]
+
         raise AttributeError("'DataFrame' object has no attribute %r" % key)
 
     def __getitem__(self, arg):
@@ -149,6 +150,9 @@ class DataFrame(object):
         """Drop the give column by *name*.
         """
         self.drop_column(name)
+
+    def __sizeof__(self):
+        return sum(col.__sizeof__() for col in self._cols.values())
 
     def __len__(self):
         """Returns the number of rows

--- a/pygdf/index.py
+++ b/pygdf/index.py
@@ -179,6 +179,9 @@ class GenericIndex(Index):
             res._values = values
             return res
 
+    def __sizeof__(self):
+        return self._values.__sizeof__()
+
     def __len__(self):
         return len(self._values)
 

--- a/pygdf/series.py
+++ b/pygdf/series.py
@@ -122,6 +122,9 @@ class Series(object):
         col = self._column.set_mask(mask, null_count=null_count)
         return self._copy_construct(data=col)
 
+    def __sizeof__(self):
+        return self._column.__sizeof__() + self._index.__sizeof__()
+
     def __len__(self):
         """Returns the size of the ``Series`` including null values.
         """

--- a/pygdf/tests/test_pickling.py
+++ b/pygdf/tests/test_pickling.py
@@ -1,0 +1,56 @@
+import sys
+import pickle
+
+import numpy as np
+import pandas as pd
+
+from pygdf.dataframe import Series, DataFrame
+
+
+def check_serialization(df):
+    assert_frame_picklable(df)
+    assert_frame_picklable(df[:-1])
+    assert_frame_picklable(df[1:])
+    assert_frame_picklable(df[2:-2])
+
+
+def assert_frame_picklable(df):
+    serialbytes = pickle.dumps(df)
+    loaded = pickle.loads(serialbytes)
+    pd.util.testing.assert_frame_equal(loaded.to_pandas(), df.to_pandas())
+
+
+def test_pickle_dataframe_numeric():
+    np.random.seed(0)
+    df = DataFrame()
+    nelem = 10
+    df['keys'] = np.arange(nelem, dtype=np.float64)
+    df['vals'] = np.random.random(nelem)
+
+    check_serialization(df)
+
+
+def test_pickle_dataframe_categorical():
+    np.random.seed(0)
+
+    df = DataFrame()
+    df['keys'] = pd.Categorical("aaabababac")
+    df['vals'] = np.random.random(len(df))
+
+    check_serialization(df)
+
+
+def test_sizeof_dataframe():
+    np.random.seed(0)
+    df = DataFrame()
+    nelem = 1000
+    df['keys'] = hkeys = np.arange(nelem, dtype=np.float64)
+    df['vals'] = hvals = np.random.random(nelem)
+
+    nbytes = hkeys.nbytes + hvals.nbytes
+    sizeof = sys.getsizeof(df)
+    assert sizeof >= nbytes
+
+    serialized_nbytes = len(pickle.dumps(df, protocol=pickle.HIGHEST_PROTOCOL))
+    # Serialized size should be close to what __sizeof__ is giving
+    np.testing.assert_approx_equal(sizeof, serialized_nbytes, significant=2)


### PR DESCRIPTION
To make Dataframe pickle-able, we only need to make a Buffer pickle-able.  
In addition, `__sizeof__` is added to the container classes to report the size of the payload.