### PR TITLE
Fix unpickling GenericIndex

### DIFF
--- a/pygdf/buffer.py
+++ b/pygdf/buffer.py
@@ -24,7 +24,9 @@ class Buffer(object):
         self.dtype = self.mem.dtype
 
     def __reduce__(self):
-        return type(self), (self.to_array(), self.size, self.capacity)
+        cpumem = self.to_array()
+        # Note: pickled Buffer only stores *size* element.
+        return type(self), (cpumem,)
 
     def __sizeof__(self):
         return self.mem.alloc_size

--- a/pygdf/index.py
+++ b/pygdf/index.py
@@ -182,6 +182,9 @@ class GenericIndex(Index):
     def __sizeof__(self):
         return self._values.__sizeof__()
 
+    def __reduce__(self):
+        return GenericIndex, tuple([self._values])
+
     def __len__(self):
         return len(self._values)
 

--- a/pygdf/tests/test_pickling.py
+++ b/pygdf/tests/test_pickling.py
@@ -5,7 +5,7 @@ import numpy as np
 from numba import cuda
 import pandas as pd
 
-from pygdf.dataframe import DataFrame, GenericIndex
+from pygdf.dataframe import DataFrame, GenericIndex, Buffer
 
 
 def check_serialization(df):
@@ -69,3 +69,17 @@ def test_pickle_index():
     pickled = pickle.dumps(idx)
     out = pickle.loads(pickled)
     assert idx == out
+
+
+def test_pickle_buffer():
+    arr = np.arange(10)
+    buf = Buffer(arr, size=4, capacity=arr.size)
+    assert buf.size == 4
+    assert buf.capacity == 10
+    pickled = pickle.dumps(buf)
+    unpacked = pickle.loads(pickled)
+    # Check that unpacked capacity equals buf.size
+    assert unpacked.size == 4
+    assert unpacked.capacity == 4
+    assert unpacked.mem.size == unpacked.capacity
+    np.testing.assert_equal(unpacked.to_array(), arr[:unpacked.size])


### PR DESCRIPTION
also make Buffer store minimal bytes