### PR TITLE
Improve groupby implementation 

### DIFF
--- a/pygdf/_gdf.py
+++ b/pygdf/_gdf.py
@@ -168,3 +168,38 @@ def apply_join(col_lhs, col_rhs, how):
 
 def apply_prefixsum(col_inp, col_out, inclusive):
     libgdf.gdf_prefixsum_generic(col_inp, col_out, inclusive)
+
+
+def apply_segsort(col_keys, col_vals, segments, descending=False):
+    # prepare
+    fullsegs = np.empty(len(segments) + 1, dtype=np.uint32)
+    begins = fullsegs[:-1]
+    begins[:] = segments
+    ends = fullsegs[1:]
+    ends[-1] = len(col_keys)
+
+    d_begins = cuda.to_device(begins)
+    d_ends = cuda.to_device(ends)
+
+    nelem = len(col_keys)
+    begin_bit = 0
+    end_bit = col_keys.dtype.itemsize * 8
+
+    sizeof_key = col_keys.data.dtype.itemsize
+    sizeof_val = col_vals.data.dtype.itemsize
+
+    # sort
+    plan = libgdf.gdf_segmented_radixsort_plan(nelem, descending,
+                                               begin_bit, end_bit)
+    try:
+        libgdf.gdf_segmented_radixsort_plan_setup(plan, sizeof_key, sizeof_val)
+        libgdf.gdf_segmented_radixsort_generic(plan,
+                                               col_keys.cffi_view,
+                                               col_vals.cffi_view,
+                                               len(segments),
+                                               unwrap_devary(d_begins),
+                                               unwrap_devary(d_ends))
+    finally:
+        libgdf.gdf_segmented_radixsort_plan_free(plan)
+
+

--- a/pygdf/column.py
+++ b/pygdf/column.py
@@ -231,6 +231,10 @@ class Column(object):
         }
         return params
 
+    def copy_data(self):
+        return self.replace(data=self.data.copy())
+
+
     def replace(self, **kwargs):
         """Replace attibutes of the class and return a new Column.
 

--- a/pygdf/cudautils.py
+++ b/pygdf/cudautils.py
@@ -606,11 +606,19 @@ def gpu_mark_seg_segments(begins, markers):
 def find_segments(arr, segs=None):
     """Find beginning indices of runs of equal values.
 
+    Parameters
+    ----------
+    arr : device array
+        The operand.
+    segs : optional; device array
+        Segment offsets that must exist in the output.
+
     Returns
     -------
     starting_indices : device array
         The starting indices of start of segments.
         Total segment count will be equal to the length of this.
+
     """
     from . import _gdf
 

--- a/pygdf/dataframe.py
+++ b/pygdf/dataframe.py
@@ -9,7 +9,7 @@ import pandas as pd
 from numba import cuda
 
 from . import cudautils, formatting, queryutils, _gdf
-from .index import GenericIndex, EmptyIndex, Index
+from .index import GenericIndex, EmptyIndex, Index, RangeIndex
 from .series import Series
 from .buffer import Buffer
 from .settings import NOTSET, settings
@@ -265,6 +265,9 @@ class DataFrame(object):
             for k in self.columns:
                 df[k] = self[k].set_index(index)
             return df
+
+    def reset_index(self):
+        return self.set_index(RangeIndex(len(self)))
 
     def copy(self):
         "Shallow copy this dataframe"

--- a/pygdf/dataframe.py
+++ b/pygdf/dataframe.py
@@ -575,13 +575,17 @@ class DataFrame(object):
             return df.sort_index()
         return df
 
-    def groupby(self, by):
+    def groupby(self, by, sort=False):
         """Groupby
 
         Parameters
         ----------
         by : list-of-str or str
             Column name(s) to form that groups by.
+        sort: bool
+            Force sorting group keys.
+            Depends on the underlying algorithm.
+            Current algorithm always sort.
 
         Returns
         -------

--- a/pygdf/series.py
+++ b/pygdf/series.py
@@ -147,7 +147,7 @@ class Series(object):
         else:
             raise NotImplementedError(type(arg))
 
-    def take(self, indices):
+    def take(self, indices, ignore_index=False):
         """Return Series by taking values from the corresponding *indices*.
         """
         indices = Buffer(indices).to_gpu_array()
@@ -158,7 +158,11 @@ class Series(object):
             mask = Buffer(mask)
         else:
             mask = None
-        index = self.index.take(indices)
+        if ignore_index:
+            index = self._index
+        else:
+            index = self.index.take(indices)
+
         col = self._column.replace(data=Buffer(data), mask=mask)
         return self._copy_construct(data=col, index=index)
 


### PR DESCRIPTION
Previous groupby is naively transversing all groups for every level in CPU to perform the grouping. This resulted in exponential scaling as the number of grouping keys increases.

The new implementation uses segmented sort (from https://github.com/gpuopenanalytics/libgdf/pull/35) to group each key level in one parallel task.  Significant speedup is observed comparing the new vs old impl.  Comparing to pandas, our new groupby achieve 3-4x speedup on a 100,000,000 rows, 5-keycols, 1-valcol groupby+mean. 

Additional note, the groupby aggregation functions needs to be improved as well.  Only the *mean* is optimized.  The other agg function will still loop over all groups.