### PR TITLE
Adding Support for Label Encoding

### DIFF
--- a/pygdf/cudautils.py
+++ b/pygdf/cudautils.py
@@ -379,12 +379,15 @@ def compute_scale(arr, vmin, vmax):
 
 @cuda.jit
 def gpu_label(arr, labarr, out):
-    i, j = cuda.grid(1), cuda.grid(1)
-    for i in range(out.size):
+    i = cuda.grid(1)
+    if i < out.size:
         val = arr[i]
-        if j < (labarr.size) / 2 and val == labarr[j][0]:
-            res = labarr[j][1]
-            out[i] = res
+        out[i] = -1
+        for j in range(labarr.shape[0]):
+            if val == labarr[j][0]:
+                res = labarr[j][1]
+                out[i] = res
+                break
 
 
 def apply_label(arr, cats, dtype):

--- a/pygdf/dataframe.py
+++ b/pygdf/dataframe.py
@@ -414,6 +414,34 @@ class DataFrame(object):
             outdf.add_column(name, col)
         return outdf
 
+    def label_encoding(self, column, prefix, cats, prefix_sep='_', dtype='float64'):
+        """Encode labels in a column with label encoding.
+
+        Parameters
+        ----------
+        column : str
+            the source column with binary encoding for the data.
+        prefix : str
+            the new column name prefix.
+        cats : sequence of ints
+            the sequence of categories as integers.
+        prefix_sep : str
+            the separator between the prefix and the category.
+        dtype :
+            the dtype for the outputs; defaults to float64.
+
+        Returns
+        -------
+        a new dataframe with new columns append for each category.
+        """
+
+        newname = prefix_sep.join([prefix, 'labels'])
+        newcol = self[column].label_encoding(cats=cats, dtype=dtype)
+        outdf = self.copy()
+        outdf.add_column(newname, newcol)
+
+        return outdf
+
     def _sort_by(self, sorted_indices):
         df = DataFrame()
         # Perform out = data[index] for all columns

--- a/pygdf/series.py
+++ b/pygdf/series.py
@@ -542,13 +542,9 @@ class Series(object):
             raise TypeError('expecting integer or float dtype')
 
         dtype = np.dtype(dtype)
-        lab = list(range(len(cats)))
         gpuarr = self.to_gpu_array()
 
-        for i, cat in enumerate(cats):
-            if i > 0:
-                gpuarr = labeled
-            labeled = cudautils.apply_label(gpuarr, cat, lab[i], dtype)
+        labeled = cudautils.apply_label(gpuarr, cats, dtype)
 
         return Series(labeled)
 

--- a/pygdf/tests/test_label_encode.py
+++ b/pygdf/tests/test_label_encode.py
@@ -1,0 +1,30 @@
+import pytest
+import pygdf
+from numba import cuda
+from pygdf.dataframe import DataFrame, Series
+
+def test_label_encode():
+    df = DataFrame()
+    np.random.seed(0)
+
+    # initialize data frame
+    df['cats'] = np.arange(10, dtype=np.int32)
+    lab = list(range(len(df['cats'])))
+
+    # label encode series
+    ncol = df['cats'].label_encoding(list(range(10)))
+    arr = ncol.to_array()
+
+    # verify labels of new column
+    for i in list(range(10)):
+        np.testing.assert_equal(arr[i], lab[i])
+
+    # label encode data frame
+    df2 = df.label_encoding(column='cats', prefix='cats', cats=list(range(10)))
+
+    assert df2.columns[0] == 'cats'
+    assert df2.columns[1] == 'cats_labels'
+
+
+if __name__ == '__main__':
+    test_label_encode()

--- a/pygdf/tests/test_label_encode.py
+++ b/pygdf/tests/test_label_encode.py
@@ -1,26 +1,29 @@
 import pytest
 import pygdf
+import numpy as np
 from numba import cuda
 from pygdf.dataframe import DataFrame, Series
+
 
 def test_label_encode():
     df = DataFrame()
     np.random.seed(0)
 
     # initialize data frame
-    df['cats'] = np.arange(10, dtype=np.int32)
-    lab = list(range(len(df['cats'])))
+    df['cats'] = np.random.randint(7, size=10, dtype=np.int32)
+    vals = df['cats'].unique_k(10)
+    lab = dict(zip(vals, list(range(len(vals)))))
 
     # label encode series
-    ncol = df['cats'].label_encoding(list(range(10)))
+    ncol = df['cats'].label_encoding(cats=vals, dtype='float32')
     arr = ncol.to_array()
 
     # verify labels of new column
-    for i in list(range(10)):
-        np.testing.assert_equal(arr[i], lab[i])
+    for i in range(arr.size):
+        np.testing.assert_equal(arr[i], lab.get(arr[i], None))
 
     # label encode data frame
-    df2 = df.label_encoding(column='cats', prefix='cats', cats=list(range(10)))
+    df2 = df.label_encoding(column='cats', prefix='cats', cats=vals, dtype='float32')
 
     assert df2.columns[0] == 'cats'
     assert df2.columns[1] == 'cats_labels'

--- a/pygdf/tests/test_label_encode.py
+++ b/pygdf/tests/test_label_encode.py
@@ -1,7 +1,8 @@
 import pytest
-import pygdf
 import numpy as np
+import random
 from numba import cuda
+import pygdf
 from pygdf.dataframe import DataFrame, Series
 
 
@@ -20,7 +21,38 @@ def test_label_encode():
 
     # verify labels of new column
     for i in range(arr.size):
-        np.testing.assert_equal(arr[i], lab.get(arr[i], None))
+        np.testing.assert_equal(arr[i], lab.get(df.cats[i], None))
+
+    # label encode data frame
+    df2 = df.label_encoding(column='cats', prefix='cats', cats=vals, dtype='float32')
+
+    assert df2.columns[0] == 'cats'
+    assert df2.columns[1] == 'cats_labels'
+
+
+def test_label_encode_drop_one():
+    random.seed(0)
+    np.random.seed(0)
+
+    df = DataFrame()
+
+    # initialize data frame
+    df['cats'] = np.random.randint(7, size=10, dtype=np.int32)
+    vals = list(df['cats'].unique_k(10))
+    # drop 1 randomly
+    del vals[random.randrange(len(vals))]
+
+    lab = dict(zip(vals, list(range(len(vals)))))
+
+    # label encode series
+    ncol = df['cats'].label_encoding(cats=vals, dtype='float32')
+    arr = ncol.to_array()
+
+    # verify labels of new column
+
+    for i in range(arr.size):
+        # assuming -1 is used for missing value
+        np.testing.assert_equal(arr[i], lab.get(df.cats[i], -1))
 
     # label encode data frame
     df2 = df.label_encoding(column='cats', prefix='cats', cats=vals, dtype='float32')
@@ -31,3 +63,4 @@ def test_label_encode():
 
 if __name__ == '__main__':
     test_label_encode()
+    test_label_encode_drop_one()


### PR DESCRIPTION
fixes #87 

- [x] Implementing Label encoding for both `Series` and `DataFrame`

- [x] User would be able to see a new column with `label encoded` values for the original column values 
