### PR TITLE
Fix joining on categorical indices

### DIFF
--- a/pygdf/buffer.py
+++ b/pygdf/buffer.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division
 
 import numpy as np
+from numba import cuda
 
 from . import cudautils, utils
 from .serialize import register_distributed_serializer
@@ -12,7 +13,16 @@ class Buffer(object):
     """
     @classmethod
     def from_empty(cls, mem):
-        return Buffer(mem, size=0, capacity=mem.size)
+        """From empty device array
+        """
+        return cls(mem, size=0, capacity=mem.size)
+
+    @classmethod
+    def null(cls, dtype):
+        """Create a "null" buffer with a zero-sized device array.
+        """
+        mem = cuda.device_array(0, dtype=dtype)
+        return cls(mem, size=0, capacity=0)
 
     def __init__(self, mem, size=None, capacity=None):
         if size is None:

--- a/pygdf/column.py
+++ b/pygdf/column.py
@@ -266,7 +266,6 @@ class Column(object):
     def copy_data(self):
         return self.replace(data=self.data.copy())
 
-
     def replace(self, **kwargs):
         """Replace attibutes of the class and return a new Column.
 

--- a/pygdf/index.py
+++ b/pygdf/index.py
@@ -81,6 +81,16 @@ class Index(object):
         res = lhs.unordered_compare('eq', rhs).all()
         return res
 
+    def join(self, other, how='left', return_indexers=False):
+        column_join_res = self.as_column().join(
+            other.as_column(), how=how, return_indexers=return_indexers)
+        if return_indexers:
+            joined_col, indexers = column_join_res
+            joined_index = GenericIndex(joined_col)
+            return joined_index, indexers
+        else:
+            return column_join_res
+
 
 class EmptyIndex(Index):
     """

--- a/pygdf/numerical.py
+++ b/pygdf/numerical.py
@@ -203,6 +203,54 @@ class NumericalColumn(columnops.TypedColumnBase):
         else:
             raise TypeError("numeric column of {} has no NaN value".format(self.dtype))
 
+    def join(self, other, how='left', return_indexers=False):
+        """Join with another column.
+
+        When the column is a index, set *return_indexers* to obtain
+        the indices for shuffling the remaining columns.
+        """
+        from .series import Series
+
+        if not self.is_type_equivalent(other):
+            raise TypeError('*other* is not compatible')
+
+        lkey, largsort = self.sort_by_values(True)
+        rkey, rargsort = other.sort_by_values(True)
+        with _gdf.apply_join(lkey, rkey, how=how) as (lidx, ridx):
+            if lidx.size > 0:
+                raw_index = cudautils.gather_joined_index(
+                    lkey.to_gpu_array(),
+                    rkey.to_gpu_array(),
+                    lidx,
+                    ridx,
+                )
+                buf_index = Buffer(raw_index)
+            else:
+                buf_index = Buffer.null(dtype=self.dtype)
+
+            joined_index = lkey.replace(data=buf_index)
+
+            if return_indexers:
+                def gather(idxrange, idx):
+                    mask = (Series(idx) != -1).as_mask()
+                    return idxrange.take(idx).set_mask(mask).fillna(-1)
+
+                if len(joined_index) > 0:
+                    idxrange = Series(columnops.as_column(
+                                        cudautils.arange(len(joined_index))))
+                    indexers = (
+                        gather(idxrange.take(largsort.to_gpu_array()), lidx),
+                        gather(idxrange.take(rargsort.to_gpu_array()), ridx),
+                    )
+                else:
+                    indexers = (
+                        Series(Buffer.null(dtype=np.intp)),
+                        Series(Buffer.null(dtype=np.intp))
+                    )
+                return joined_index, indexers
+            else:
+                return joined_index
+
 
 def numeric_column_binop(lhs, rhs, op, out_dtype):
     if lhs.dtype != rhs.dtype:

--- a/pygdf/numerical.py
+++ b/pygdf/numerical.py
@@ -236,11 +236,9 @@ class NumericalColumn(columnops.TypedColumnBase):
                     return idxrange.take(idx).set_mask(mask).fillna(-1)
 
                 if len(joined_index) > 0:
-                    idxrange = Series(columnops.as_column(
-                                        cudautils.arange(len(joined_index))))
                     indexers = (
-                        gather(idxrange.take(largsort.to_gpu_array()), lidx),
-                        gather(idxrange.take(rargsort.to_gpu_array()), ridx),
+                        gather(Series(largsort), lidx),
+                        gather(Series(rargsort), ridx),
                     )
                 else:
                     indexers = (


### PR DESCRIPTION
Closes #109 


* Add .set_categories to categorical column
* Refactor join to push the index join part into the index type and the underlying column type.  This is closer to how pandas implement join.

