### PR TITLE
Pin pandas version to 0.20.3 in testing environment

### DIFF
--- a/conda_environments/testing_py35.yml
+++ b/conda_environments/testing_py35.yml
@@ -11,4 +11,4 @@ dependencies:
 - libgdf=0.1.0a2.dev
 - libgdf_cffi=0.1.0a2.dev
 - numba>=0.35.0
-- pandas=0.21.*
+- pandas=0.20.3


### PR DESCRIPTION
Pin pandas version to 0.20.3 in testing environment until Pandas 0.21+ fixes are pushed, should fix failed join tests as well.