### PR TITLE
Add notebook dependency to testing_py35.yml

### DIFF
--- a/conda_environments/testing_py35.yml
+++ b/conda_environments/testing_py35.yml
@@ -12,3 +12,4 @@ dependencies:
 - libgdf_cffi=0.1.0a2.dev
 - numba>=0.35.0
 - pandas=0.20.3
+- notebook>=0.5.0


### PR DESCRIPTION
On master https://github.com/gpuopenanalytics/pygdf/commit/87768415a0845921aba35d23944dd46e2e28e446, the conda environment in `notebook_py35.yml` is broken, giving error messages similar to #101 and #117. I believe this is due to https://github.com/gpuopenanalytics/pygdf/blob/master/conda_environments/notebook_py35.yml#L84-L85 having outdated version libraries. 

For maintainability, it seems like bundling Jupyter notebook within the `pygdf_dev` environment makes more sense, and then two .yml files don't need to be maintained. I labeled this PR as [WIP] because I didn't want to delete the `notebook_py35.yml` file in case someone thinks it should stay, but if everyone agrees I can push another commit to remove `notebook_py35.yml`.