### PR TITLE
[WIP] Context-aware data transfer in dask

### DIFF
--- a/pygdf/dataframe.py
+++ b/pygdf/dataframe.py
@@ -353,7 +353,7 @@ class DataFrame(object):
             arr = cuda.device_array(shape=len(index), dtype=series.dtype)
             cudautils.gpu_fill_value.forall(arr.size)(arr, col)
             return Series(arr)
-        elif len(self) > 0 and sind != index:
+        elif len(self) > 0 and len(sind) != len(index):
             raise ValueError('Length of values does not match index length')
         return col
 

--- a/pygdf/dataframe.py
+++ b/pygdf/dataframe.py
@@ -12,6 +12,7 @@ from numba.cuda.cudadrv.devicearray import DeviceNDArray
 from . import cudautils, formatting, queryutils, _gdf, applyutils, utils
 from .index import GenericIndex, EmptyIndex, Index, RangeIndex
 from .series import Series
+from .column import Column
 from .buffer import Buffer
 from .settings import NOTSET, settings
 from .serialize import register_distributed_serializer
@@ -346,7 +347,8 @@ class DataFrame(object):
         index = self._index
         series = Series(col)
         sind = series.index
-        VALID = isinstance(col, (np.ndarray, DeviceNDArray, list, Series))
+        VALID = isinstance(col, (np.ndarray, DeviceNDArray, list, Series,
+                                 Column))
         if len(self) > 0 and len(series) == 1 and not VALID:
             arr = cuda.device_array(shape=len(index), dtype=series.dtype)
             cudautils.gpu_fill_value.forall(arr.size)(arr, col)

--- a/pygdf/dataframe.py
+++ b/pygdf/dataframe.py
@@ -85,7 +85,7 @@ class DataFrame(object):
         # has initializer?
         if name_series is not None:
             for k, series in name_series:
-                self.add_column(k, series)
+                self.add_column(k, series, forceindex=index is not None)
 
     def serialize(self, serialize):
         header = {}
@@ -328,7 +328,7 @@ class DataFrame(object):
         series = Series(col)
         if len(self) == 0 and len(self.columns) > 0 and len(series) > 0:
             ind = series.index
-            arr = cuda.device_array(shape=len(ind),dtype=np.float64)
+            arr = cuda.device_array(shape=len(ind), dtype=np.float64)
             size = utils.calc_chunk_size(arr.size, utils.mask_bitsize)
             mask = cudautils.zeros(size, dtype=utils.mask_dtype)
             val = Series.from_masked_array(arr, mask, null_count=len(ind))

--- a/pygdf/serialize.py
+++ b/pygdf/serialize.py
@@ -5,18 +5,60 @@ except ImportError:
         pass
 else:
     import distributed.protocol as _dp
+    from distributed.utils import has_keyword
 
     def register_distributed_serializer(cls):
         _dp.register_serialization(cls, _serialize, _deserialize)
 
-    def _serialize(df):
-        header, frames = df.serialize(_dp.serialize)
-        assert 'reconstructor' not in header
-        meth_deserial = getattr(type(df), 'deserialize')
-        header['reconstructor'] = _dp.serialize(meth_deserial)
-        return header, frames
+    def _serialize(df, context=None):
+        def _serialize_imp(df, context=None):
+            def do_serialize(x):
+                return _dp.serialize(x, context=context)
+
+            def call_with_context(meth, x, *args):
+                if has_keyword(meth, 'context'):
+                    return meth(x, context=context)
+                else:
+                    return meth(x)
+
+            header, frames = call_with_context(df.serialize, do_serialize)
+            assert 'reconstructor' not in header
+            meth_deserial = getattr(type(df), 'deserialize')
+            header['reconstructor'] = do_serialize(meth_deserial)
+            return header, frames
+
+        try:
+            return _serialize_imp(df, context=context)
+        except:
+            import traceback
+            traceback.print_exc()
+            raise
 
     def _deserialize(header, frames):
         reconstructor = _dp.deserialize(*header['reconstructor'])
         assert reconstructor is not None, 'None {}'.format(header['type'])
         return reconstructor(_dp.deserialize, header, frames)
+
+
+def _parse_transfer_context(context):
+    from distributed.comm.addressing import parse_host_port, parse_address
+
+    def parse_it(x):
+        return parse_host_port(parse_address(x)[1])
+
+    if 'recipient' in context and 'sender' in context:
+        rechost, recport = parse_it(context['recipient'])
+        senhost, senport = parse_it(context['sender'])
+        same_node = rechost == senhost
+        same_process = same_node and recport == senport
+    else:
+        same_node, same_process = False, False
+    return same_node, same_process
+
+
+def should_use_ipc(context):
+    if context is None:
+        return False
+    same_node, same_process = _parse_transfer_context(context)
+    return bool(same_node)
+

--- a/pygdf/tests/test_dataframe.py
+++ b/pygdf/tests/test_dataframe.py
@@ -448,3 +448,11 @@ def test_dataframe_append_to_empty():
     gdf['b'] = [1, 2, 3]
 
     pd.testing.assert_frame_equal(gdf.to_pandas(), pdf)
+
+
+def test_dataframe_setitem_index_len1():
+    gdf = DataFrame()
+    gdf['a'] = [1]
+    gdf['b'] = gdf.index.as_column()
+
+    np.testing.assert_equal(gdf.b.to_array(), [0])

--- a/pygdf/tests/test_serialize.py
+++ b/pygdf/tests/test_serialize.py
@@ -26,6 +26,18 @@ def test_serialize_dataframe():
 
 
 @require_distributed
+def test_serialize_dataframe_with_index():
+    df = pygdf.DataFrame()
+    df['a'] = np.arange(100)
+    df['b'] = np.random.random(100)
+    df['c'] = pd.Categorical(['a', 'b', 'c', '_', '_'] * 20,
+                             categories=['a', 'b', 'c'])
+    df = df.sort_values('b')
+    outdf = deserialize(*serialize(df))
+    pd.util.testing.assert_frame_equal(df.to_pandas(), outdf.to_pandas())
+
+
+@require_distributed
 def test_serialize_series():
     sr = pygdf.Series(np.arange(100))
     outsr = deserialize(*serialize(sr))


### PR DESCRIPTION
Based on:

* https://github.com/dask/distributed/pull/2054
* https://github.com/dask/distributed/pull/2052

Improve dask data transfer by using context information to decide when to use CUDA IPC and when to send via normal serialization method (usually pickling).

Status: the implementation is working but I would like to do more testing on big multigpu machines and may do some fine tuning.
