### PR TITLE
Dockerfile: Fix libgdf build after cmake PR landed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,17 @@ ARG CUDA_VERSION=9.2
 ARG LINUX_VERSION=ubuntu16.04
 FROM nvidia/cuda:${CUDA_VERSION}-devel-${LINUX_VERSION}
 
+ARG CC=5
+ARG CXX=5
+
 RUN apt update -y --fix-missing && \
     apt upgrade -y && \
     apt install -y \
       git \
-      gcc-4.8 \
-      g++-4.8
+      gcc-${CC} \
+      g++-${CXX} \
+      libboost-dev \
+      cmake
 
 # Install conda
 ADD https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh /miniconda.sh
@@ -27,8 +32,8 @@ ARG PYTHON_VERSION=3.6
 RUN conda env create -n gdf python=${PYTHON_VERSION} --file /conda_environments/gdf_build.yml
 
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/lib
-ARG CC=/usr/bin/gcc-4.8
-ARG CXX=/usr/bin/g++-4.8
+ENV CC=/usr/bin/gcc
+ENV CXX=/usr/bin/g++
 
 # Specify alternate URLs via build-args to build against forks, other branches, or specific PR
 ARG LIBGDF_REPO=https://github.com/gpuopenanalytics/libgdf

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ A Dockerfile is provided for building and installing LibGDF and PyGDF from their
 * Alternate branches for libgdf and pygdf may be specified as Docker build-args LIBGDF_REPO and PYGDF_REPO. See Dockerfile for example.
 * Ubuntu 16.04 is the default OS for this container. Alternate OSes may be specified as Docker build-arg LINUX_VERSION. See list of [available images](https://hub.docker.com/r/nvidia/cuda/).
 * Python 3.6 is default, but other versions may be specified via PYTHON_VERSION build-arg
-* GCC & G++ 4.8 are default for ABI compatibility with [Apache Arrow](http://arrow.apache.org/) version, but other versions may be specified via CC and CXX build-args respectively
+* GCC & G++ 5.x are default compiler versions, but other versions (which are supplied by the OS package manager) may be specified via CC and CXX build-args respectively
 
 From pygdf project root, to build with defaults:
 ```

--- a/conda_environments/gdf_build.yml
+++ b/conda_environments/gdf_build.yml
@@ -6,10 +6,7 @@ channels:
 dependencies:
 - pip
 - setuptools
-- cmake
 # Update based on your host's CUDA driver version
 - cudatoolkit
 - numba
 - pandas
-- flatbuffers
-- arrow-cpp=0.7.1


### PR DESCRIPTION
Removed cmake, libarrow from conda packages, added cmake, libboost to apt packages, bumped gcc and g++ versions, updated README