### PR TITLE
Fix tests due to missing re-export

### DIFF
--- a/pygdf/__init__.py
+++ b/pygdf/__init__.py
@@ -1,6 +1,19 @@
 # Copyright (c) 2018, NVIDIA CORPORATION.
+from .dataframe import DataFrame
+from .series import Series
+from .multi import concat
+
+from .settings import set_options
+
 
 # Versioneer
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
+
+__all__ = [
+    DataFrame,
+    Series,
+    concat,
+    set_options,
+]

--- a/pygdf/tests/test_pickling.py
+++ b/pygdf/tests/test_pickling.py
@@ -7,7 +7,8 @@ import numpy as np
 from numba import cuda
 import pandas as pd
 
-from pygdf.dataframe import DataFrame, GenericIndex, Buffer
+from pygdf.dataframe import DataFrame, GenericIndex
+from pygdf.buffer import Buffer
 
 
 def check_serialization(df):


### PR DESCRIPTION
Currently, master is failing tests because the symbols are not re-exported as required.  