### PR TITLE
Fix for pytest in test_joining.py

### DIFF
--- a/pygdf/_gdf.py
+++ b/pygdf/_gdf.py
@@ -135,8 +135,8 @@ def apply_sort(col_keys, col_vals, ascending=True):
 _join_how_api = {
     'inner': libgdf.gdf_inner_join_generic,
     'outer': libgdf.gdf_outer_join_generic,
-    'left': libgdf.gdf_multi_left_join_generic,
-    'left-compat': libgdf.gdf_left_join_generic,
+    'multi-left': libgdf.gdf_multi_left_join_generic,
+    'left': libgdf.gdf_left_join_generic,
 }
 
 
@@ -162,7 +162,7 @@ def apply_join(col_lhs, col_rhs, how):
     joiner = _join_how_api[how]
     join_result_ptr = ffi.new("gdf_join_result_type**", None)
 
-    if(how == 'left'):
+    if(how == 'multi-left'):
         list_lhs = []
         list_rhs = []
         for i in range(len(col_lhs)):

--- a/pygdf/_gdf.py
+++ b/pygdf/_gdf.py
@@ -135,8 +135,8 @@ def apply_sort(col_keys, col_vals, ascending=True):
 _join_how_api = {
     'inner': libgdf.gdf_inner_join_generic,
     'outer': libgdf.gdf_outer_join_generic,
-    'multi-left': libgdf.gdf_multi_left_join_generic,
-    'left': libgdf.gdf_left_join_generic,
+    'left': libgdf.gdf_multi_left_join_generic,
+    'left-compat': libgdf.gdf_left_join_generic,
 }
 
 
@@ -162,7 +162,7 @@ def apply_join(col_lhs, col_rhs, how):
     joiner = _join_how_api[how]
     join_result_ptr = ffi.new("gdf_join_result_type**", None)
 
-    if(how == 'multi-left'):
+    if(how == 'left'):
         list_lhs = []
         list_rhs = []
         for i in range(len(col_lhs)):

--- a/pygdf/dataframe.py
+++ b/pygdf/dataframe.py
@@ -643,8 +643,8 @@ class DataFrame(object):
         #    lhs, rhs, left_on=on, right_on=on, how=how,
         #    return_joined_indicies=True)
         joined_values, joined_indicies = self._merge_gdf(
-            lhs, rhs, left_on=on, right_on=on, how='multi-left', return_indices=True
-            )
+            lhs, rhs, left_on=on, right_on=on, how='multi-left',
+            return_indices=True)
 
         # XXX: Prepare output.  same as _join.  code duplication
         # Perform left, inner and outer join

--- a/pygdf/dataframe.py
+++ b/pygdf/dataframe.py
@@ -643,7 +643,7 @@ class DataFrame(object):
         #    lhs, rhs, left_on=on, right_on=on, how=how,
         #    return_joined_indicies=True)
         joined_values, joined_indicies = self._merge_gdf(
-            lhs, rhs, left_on=on, right_on=on, how='multi-left',
+            lhs, rhs, left_on=on, right_on=on, how=how,
             return_indices=True)
 
         # XXX: Prepare output.  same as _join.  code duplication
@@ -679,7 +679,7 @@ class DataFrame(object):
 
         from pygdf import cudautils
 
-        assert how == 'multi-left'
+        assert how == 'left'
         assert return_indices
         assert len(left_on) == len(right_on)
 

--- a/pygdf/dataframe.py
+++ b/pygdf/dataframe.py
@@ -643,7 +643,7 @@ class DataFrame(object):
         #    lhs, rhs, left_on=on, right_on=on, how=how,
         #    return_joined_indicies=True)
         joined_values, joined_indicies = self._merge_gdf(
-            lhs, rhs, left_on=on, right_on=on, how=how, return_indices=True
+            lhs, rhs, left_on=on, right_on=on, how='multi-left', return_indices=True
             )
 
         # XXX: Prepare output.  same as _join.  code duplication
@@ -679,7 +679,7 @@ class DataFrame(object):
 
         from pygdf import cudautils
 
-        assert how == 'left'
+        assert how == 'multi-left'
         assert return_indices
         assert len(left_on) == len(right_on)
 

--- a/pygdf/numerical.py
+++ b/pygdf/numerical.py
@@ -265,6 +265,8 @@ class NumericalColumn(columnops.TypedColumnBase):
 
         lkey, largsort = self.sort_by_values(True)
         rkey, rargsort = other.sort_by_values(True)
+        if how == 'left':
+            how = 'left-compat'
         with _gdf.apply_join([lkey], [rkey], how=how) as (lidx, ridx):
             if lidx.size > 0:
                 raw_index = cudautils.gather_joined_index(


### PR DESCRIPTION
Running pytest on pygdf root folder fails for GDF containing columns of type np.float32 and np.float64. Until they are supported in libgdf.gdf_multi_left_join_generic, this should be a solution.