### PR TITLE
GPU CI - Add build status icon to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PyGDF
 
-[![Documentation Status](https://readthedocs.org/projects/pygdf/badge/?version=latest)](http://pygdf.readthedocs.io/en/latest/?badge=latest)
+[![Build Status](http://18.191.94.64/buildStatus/icon?job=pygdf-master)](http://18.191.94.64/job/pygdf-master/)&nbsp;&nbsp;[![Documentation Status](https://readthedocs.org/projects/pygdf/badge/?version=latest)](http://pygdf.readthedocs.io/en/latest/?badge=latest)
 
 PyGDF implements the Python interface to access and manipulate the GPU DataFrame of [GPU Open Analytics Initiative (GoAi)](http://gpuopenanalytics.com/).  We aim to provide a simple interface that is similar to the Pandas DataFrame and hide the details of GPU programming. 
 


### PR DESCRIPTION
To match `libgdf` and link to the master GPU CI builds for `pygdf` Pull request testing is active as well. Working on documentation for that separately.