### PR TITLE
[REVIEW] Multicolumn getindex similar to pandas in dataframe.py

### DIFF
--- a/pygdf/dataframe.py
+++ b/pygdf/dataframe.py
@@ -146,6 +146,9 @@ class DataFrame(object):
         If *arg* is a ``str``, return the column Series.
         If *arg* is a ``slice``, return a new DataFrame with all columns
         sliced to the specified range.
+        If *arg* is an ``array`` containing column names, return a new
+        DataFrame with the corresponding columns.
+
 
         Examples
         --------
@@ -165,6 +168,12 @@ class DataFrame(object):
         17   17   17   17
         18   18   18   18
         19   19   19   19
+        >>>df[['a','c']] # get columns a and c
+             a    c
+        0    0    0
+        1    1    1
+        2    2    2
+        3    3    3
         """
         if isinstance(arg, str) or isinstance(arg, int):
             return self._cols[arg]
@@ -172,6 +181,11 @@ class DataFrame(object):
             df = DataFrame()
             for k, col in self._cols.items():
                 df[k] = col[arg]
+            return df
+        elif isinstance(arg, (list,)):
+            df = DataFrame()
+            for col in arg:
+                df[col] = self[col]
             return df
         else:
             msg = "__getitem__ on type {!r} is not supported"

--- a/pygdf/tests/test_dataframe.py
+++ b/pygdf/tests/test_dataframe.py
@@ -12,6 +12,8 @@ from pygdf.dataframe import Series, DataFrame
 from pygdf.buffer import Buffer
 from pygdf.settings import set_options
 
+from itertools import combinations
+
 from . import utils
 
 
@@ -157,6 +159,17 @@ def test_dataframe_column_name_indexing():
                             np.asarray(range(10), dtype=np.int32))
     np.testing.assert_equal(df[1].to_array(),
                             np.asarray(range(10), dtype=np.int32))
+
+    pdf = pd.DataFrame()
+    nelem = 10
+    pdf['key1'] = np.random.randint(0, 5, nelem)
+    pdf['key2'] = np.random.randint(0, 3, nelem)
+    pdf[1] = np.arange(1, 1 + nelem)
+    pdf[2] = np.random.random(nelem)
+    df = DataFrame.from_pandas(pdf)
+    for i in range(1, len(pdf.columns)+1):
+        for idx in combinations(pdf.columns, i):
+            assert(pdf[list(idx)].equals(df[list(idx)].to_pandas()))
 
 
 def test_dataframe_column_add_drop():


### PR DESCRIPTION
Added indexing by multiple column names to pygdf, similar to pandas: 

```
>>> df = DataFrame([('a', list(range(20))),
        ...                 ('b', list(range(20))),
        ...                 ('c', list(range(20)))])

>>>df[['a','c']] # get columns a and c
             a    c
        0    0    0
        1    1    1
        2    2    2
        3    3    3
```