### PR TITLE
[REVIEW] DataFrame to row major GPU matrix implementation (in pygdf-numba)

### DIFF
--- a/pygdf/dataframe.py
+++ b/pygdf/dataframe.py
@@ -431,7 +431,7 @@ class DataFrame(object):
         columns: sequence of str
             List of a column names to be extracted.  The order is preserved.
             If None is specified, all columns are used.
-        format: 'column' or 'row'
+        order: 'F' or 'C'
             Optional argument to determine whether to return a column major
             (Fortran) matrix or a row major (C) matrix.
 

--- a/pygdf/tests/test_dataframe.py
+++ b/pygdf/tests/test_dataframe.py
@@ -355,7 +355,8 @@ def test_dataframe_dir_and_getattr():
         df.not_a_column
 
 
-def test_dataframe_as_gpu_matrix():
+@pytest.mark.parametrize('format', ['row','column'])
+def test_dataframe_as_gpu_matrix(format):
     df = DataFrame()
 
     nelem = 123
@@ -363,13 +364,13 @@ def test_dataframe_as_gpu_matrix():
         df[k] = np.random.random(nelem)
 
     # Check all columns
-    mat = df.as_gpu_matrix().copy_to_host()
+    mat = df.as_gpu_matrix(format=format, ).copy_to_host()
     assert mat.shape == (nelem, 4)
     for i, k in enumerate(df.columns):
         np.testing.assert_array_equal(df[k].to_array(), mat[:, i])
 
     # Check column subset
-    mat = df.as_gpu_matrix(columns=['a', 'c']).copy_to_host()
+    mat = df.as_gpu_matrix(format=format, columns=['a', 'c']).copy_to_host()
     assert mat.shape == (nelem, 2)
 
     for i, k in enumerate('ac'):

--- a/pygdf/tests/test_dataframe.py
+++ b/pygdf/tests/test_dataframe.py
@@ -355,8 +355,8 @@ def test_dataframe_dir_and_getattr():
         df.not_a_column
 
 
-@pytest.mark.parametrize('format', ['row','column'])
-def test_dataframe_as_gpu_matrix(format):
+@pytest.mark.parametrize('order', ['C', 'F'])
+def test_dataframe_as_gpu_matrix(order):
     df = DataFrame()
 
     nelem = 123
@@ -364,13 +364,13 @@ def test_dataframe_as_gpu_matrix(format):
         df[k] = np.random.random(nelem)
 
     # Check all columns
-    mat = df.as_gpu_matrix(format=format, ).copy_to_host()
+    mat = df.as_gpu_matrix(order=order).copy_to_host()
     assert mat.shape == (nelem, 4)
     for i, k in enumerate(df.columns):
         np.testing.assert_array_equal(df[k].to_array(), mat[:, i])
 
     # Check column subset
-    mat = df.as_gpu_matrix(format=format, columns=['a', 'c']).copy_to_host()
+    mat = df.as_gpu_matrix(order=order, columns=['a', 'c']).copy_to_host()
     assert mat.shape == (nelem, 2)
 
     for i, k in enumerate('ac'):


### PR DESCRIPTION
Modification to `DataFrame.as_gpu_matrix()` to allow row major GPU matrix for ML algorithms. 

Function now takes `order` parameter:

`def as_gpu_matrix(self, columns=None, order='F')`

Left column major (`F`) as default in case it could break any existing code.