### PR TITLE
[REVIEW] Fixes #174: Drop Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ env:
 
 matrix:
   include:
+    - env: PYTHON=3.7
     - env: PYTHON=3.6
     - env: PYTHON=3.5
-    - env: PYTHON=2.7
 
 before_install:
   # install miniconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ env:
 
 matrix:
   include:
-    - env: PYTHON=3.7
     - env: PYTHON=3.6
     - env: PYTHON=3.5
 


### PR DESCRIPTION
Drop Python 2.7 builds and add Python 3.7 builds with TravisCI. GPUCI will need to be updated accordingly.