### PR TITLE
[REVIEW] Calculating Null Mask when creating series/columns from device type objects, solving issue 135 and 183.

### DIFF
--- a/pygdf/columnops.py
+++ b/pygdf/columnops.py
@@ -148,7 +148,7 @@ def as_column(arbitrary):
 
     elif cuda.devicearray.is_cuda_ndarray(arbitrary):
         data = as_column(Buffer(arbitrary))
-        if data.dtype != np.bool:
+        if data.dtype in [np.float16, np.float32, np.float64]:
             mask = cudautils.mask_from_devary(arbitrary)
             data = data.set_mask(mask)
 

--- a/pygdf/cudautils.py
+++ b/pygdf/cudautils.py
@@ -274,16 +274,45 @@ def gpu_mask_from_devary(ary, bits):
     for i in range(base, base + mask_bitsize):
         if i >= len(ary):
             break
-    # NOTE: Numba does not run with isnan(a) when a is int,
-    # need to cast to float
+        if not isnan(ary[i]):
+            mask_set(bits, i)
+
+@cuda.jit
+def gpu_mask_from_devary_int(ary, bits):
+    tid = cuda.grid(1)
+    base = tid * mask_bitsize
+    for i in range(base, base + mask_bitsize):
+        if i >= len(ary):
+            break
         if not isnan(float(ary[i])):
             mask_set(bits, i)
+
+# @cuda.jit
+# def gpu_mask_from_devary_bool(ary, bits):
+#     tid = cuda.grid(1)
+#     base = tid * mask_bitsize
+#     for i in range(base, base + mask_bitsize):
+#         if i >= len(ary):
+#             break
+#         if not ary[i]:
+#             mask_set(bits, i)
 
 
 def mask_from_devary(ary):
     bits = make_mask(len(ary))
     gpu_fill_value.forall(bits.size)(bits, 0)
-    gpu_mask_from_devary.forall(bits.size)(ary, bits)
+    # NOTE: Numba does not run with isnan(a) when a is int,
+    # need to cast to float
+    print("TYPE::::::: ", ary.dtype)
+    if ary.dtype in [np.int8, np.int16, np.int32, np.int32, np.int64,
+                    np.uint8, np.uint16, np.uint32, np.uint32, np.uint64]:
+        cast = True
+        gpu_mask_from_devary_int.forall(bits.size)(ary, bits)
+    # elif ary.dtype == np.bool:
+    #     gpu_mask_from_devary_bool.forall(bits.size)(ary, bits)
+    else:
+        cast = False
+        gpu_mask_from_devary.forall(bits.size)(ary, bits)
     return bits
 
 #

--- a/pygdf/cudautils.py
+++ b/pygdf/cudautils.py
@@ -274,9 +274,7 @@ def gpu_mask_from_devary(ary, bits):
     for i in range(base, base + mask_bitsize):
         if i >= len(ary):
             break
-        # NOTE: nan checking functions just work for float values, using
-        # property of nan != nan to check instead.
-        if ary[i] == ary[i]:
+        if not isnan(ary[i]):
             mask_set(bits, i)
 
 

--- a/pygdf/cudautils.py
+++ b/pygdf/cudautils.py
@@ -277,6 +277,7 @@ def gpu_mask_from_devary(ary, bits):
         if not isnan(ary[i]):
             mask_set(bits, i)
 
+
 @cuda.jit
 def gpu_mask_from_devary_int(ary, bits):
     tid = cuda.grid(1)
@@ -301,17 +302,12 @@ def gpu_mask_from_devary_int(ary, bits):
 def mask_from_devary(ary):
     bits = make_mask(len(ary))
     gpu_fill_value.forall(bits.size)(bits, 0)
-    # NOTE: Numba does not run with isnan(a) when a is int,
-    # need to cast to float
-    print("TYPE::::::: ", ary.dtype)
+    # NOTE: Numba does not accept isnan(a) when a is int, due to unimplemented
+    # int64 isnan, so need to cast to float for all int dtypes
     if ary.dtype in [np.int8, np.int16, np.int32, np.int32, np.int64,
-                    np.uint8, np.uint16, np.uint32, np.uint32, np.uint64]:
-        cast = True
+                     np.uint8, np.uint16, np.uint32, np.uint32, np.uint64]:
         gpu_mask_from_devary_int.forall(bits.size)(ary, bits)
-    # elif ary.dtype == np.bool:
-    #     gpu_mask_from_devary_bool.forall(bits.size)(ary, bits)
     else:
-        cast = False
         gpu_mask_from_devary.forall(bits.size)(ary, bits)
     return bits
 

--- a/pygdf/cudautils.py
+++ b/pygdf/cudautils.py
@@ -288,16 +288,6 @@ def gpu_mask_from_devary_int(ary, bits):
         if not isnan(float(ary[i])):
             mask_set(bits, i)
 
-# @cuda.jit
-# def gpu_mask_from_devary_bool(ary, bits):
-#     tid = cuda.grid(1)
-#     base = tid * mask_bitsize
-#     for i in range(base, base + mask_bitsize):
-#         if i >= len(ary):
-#             break
-#         if not ary[i]:
-#             mask_set(bits, i)
-
 
 def mask_from_devary(ary):
     bits = make_mask(len(ary))

--- a/pygdf/tests/test_dataframe.py
+++ b/pygdf/tests/test_dataframe.py
@@ -470,7 +470,7 @@ def test_dataframe_append_empty():
     pd.testing.assert_frame_equal(gdf.to_pandas(), pdf)
 
 
-def test_masked_setitem_from_object():
+def test_dataframe_setitem_from_masked_object():
     ary = np.random.randn(100)
     mask = np.zeros(100, dtype=bool)
     mask[:20] = True

--- a/pygdf/tests/test_dataframe.py
+++ b/pygdf/tests/test_dataframe.py
@@ -470,6 +470,27 @@ def test_dataframe_append_empty():
     pd.testing.assert_frame_equal(gdf.to_pandas(), pdf)
 
 
+def test_masked_setitem_from_object():
+    ary = np.random.randn(100)
+    mask = np.zeros(100, dtype=bool)
+    mask[:20] = True
+    np.random.shuffle(mask)
+    ary[mask] = np.nan
+
+    test1 = Series(ary)
+    assert(test1.has_null_mask)
+    assert(test1.null_count == 20)
+
+    test2 = DataFrame.from_pandas(pd.DataFrame({'a': ary}))
+    assert(test2['a'].has_null_mask)
+    assert(test2['a'].null_count == 20)
+
+    gpu_ary = cuda.to_device(ary)
+    test3 = Series(gpu_ary)
+    assert(test3.has_null_mask)
+    assert(test3.null_count == 20)
+
+
 def test_dataframe_append_to_empty():
     pdf = pd.DataFrame()
     pdf['a'] = []

--- a/pygdf/tests/test_dataframe.py
+++ b/pygdf/tests/test_dataframe.py
@@ -490,6 +490,12 @@ def test_dataframe_setitem_from_masked_object():
     assert(test3.has_null_mask)
     assert(test3.null_count == 20)
 
+    test4 = DataFrame()
+    lst = [1, 2, None, 4, 5, 6, None, 8, 9]
+    test4['lst'] = lst
+    assert(test4['lst'].has_null_mask)
+    assert(test4['lst'].null_count == 2)
+
 
 def test_dataframe_append_to_empty():
     pdf = pd.DataFrame()

--- a/pygdf/tests/test_label_encode.py
+++ b/pygdf/tests/test_label_encode.py
@@ -101,7 +101,7 @@ def test_label_encode_float_output():
                             cats=cats, dtype=np.float32,
                             na_sentinel=np.nan)
 
-    got = df2['cats_labels'].to_array()
+    got = df2['cats_labels'].to_array(fillna='pandas')
 
     handcoded = np.array([encoder.get(v, np.nan) for v in arr])
     np.testing.assert_equal(got, handcoded)

--- a/pygdf/tests/test_pandas_interop.py
+++ b/pygdf/tests/test_pandas_interop.py
@@ -47,10 +47,10 @@ def test_from_pandas_ex1():
 
     assert tuple(df.columns) == tuple(pdf.columns)
     assert np.all(df['a'].to_array() == pdf['a'])
-    matches = df['b'].to_array() == pdf['b']
+    matches = df['b'].to_array(fillna='pandas') == pdf['b']
     # the 3d element is False due to (nan == nan) == False
     assert np.all(matches == [True, True, False, True])
-    assert np.isnan(df['b'].to_array()[2])
+    assert np.isnan(df['b'].to_array(fillna='pandas')[2])
     assert np.isnan(pdf['b'][2])
 
 
@@ -61,8 +61,8 @@ def test_from_pandas_with_index():
     df = DataFrame.from_pandas(pdf)
 
     # Check columns
-    np.testing.assert_array_equal(df.a.to_array(), pdf.a)
-    np.testing.assert_array_equal(df.b.to_array(), pdf.b)
+    np.testing.assert_array_equal(df.a.to_array(fillna='pandas'), pdf.a)
+    np.testing.assert_array_equal(df.b.to_array(fillna='pandas'), pdf.b)
     # Check index
     np.testing.assert_array_equal(df.index.values, pdf.index.values)
     # Check again using pandas testing tool on frames


### PR DESCRIPTION
Modifications to calculate the null mask when creating series and/or columns from device type arrays. Solves issues 135 and 183. 

Needed workarounds since Numba cannot perform `isnan` with `int` type columns (due to unimplemented `int64` lowering support). 

IMPORTANT:: Question that needs to be answered before merging: should `to_array(self, fillna=None)` in `colunm.py` default to `fillna=pandas`. As it is right now, it ignores masked values by default, with `=pandas` it fills them with `nan`. With current behavior tests needed to be changed, but I am unsure what the better default behavior is.