### PR TITLE
[REVIEW] initial categorical unique and value count tests

### DIFF
--- a/pygdf/tests/test_categorical.py
+++ b/pygdf/tests/test_categorical.py
@@ -237,3 +237,56 @@ def test_cat_series_binop_error():
     with pytest.raises(TypeError) as raises:
         dfb + dfa
     raises.match("'add' operator not supported")
+
+
+@pytest.mark.parametrize('num_elements', [10, 100, 1000])
+def test_categorical_unique(num_elements):
+    import string
+        
+    # create categorical series
+    np.random.seed(12)
+    pd_cat = pd.Categorical(
+        pd.Series(np.random.choice(list(string.ascii_letters), num_elements), 
+            dtype="category")
+        )
+
+    # gdf
+    gdf = DataFrame()
+    gdf['a'] = Series.from_categorical(pd_cat)
+    gdf_unique_sorted = np.sort(gdf['a'].unique())
+    
+    # pandas
+    pdf = pd.DataFrame()
+    pdf['a'] = pd_cat
+    pdf_unique_sorted = np.sort(pdf['a'].unique())
+    
+    # verify
+    np.testing.assert_array_equal(pdf_unique_sorted, gdf_unique_sorted)
+
+
+@pytest.mark.parametrize('num_elements', [10, 100, 1000])
+def test_categorical_value_counts(num_elements):
+    import string
+    
+    # create categorical series
+    np.random.seed(12)
+    pd_cat = pd.Categorical(
+        pd.Series(np.random.choice(list(string.ascii_letters), num_elements), 
+            dtype="category")
+        )
+
+    # gdf
+    gdf = DataFrame()
+    gdf['a'] = Series.from_categorical(pd_cat)
+    gdf_value_counts = gdf['a'].value_counts()
+    
+    # pandas
+    pdf = pd.DataFrame()
+    pdf['a'] = pd_cat
+    pdf_value_counts = pdf['a'].value_counts()
+    
+    # verify
+    pandas_dict = pdf_value_counts.to_dict()
+    gdf_dict = gdf_value_counts.to_pandas().to_dict()
+    
+    assert pandas_dict == gdf_dict

--- a/pygdf/tests/test_categorical.py
+++ b/pygdf/tests/test_categorical.py
@@ -241,13 +241,13 @@ def test_cat_series_binop_error():
 
 @pytest.mark.parametrize('num_elements', [10, 100, 1000])
 def test_categorical_unique(num_elements):
-    import string
+    from string import ascii_letters, digits
 
     # create categorical series
     np.random.seed(12)
     pd_cat = pd.Categorical(
         pd.Series(
-            np.random.choice(list(string.ascii_letters), num_elements),
+            np.random.choice(list(ascii_letters + digits), num_elements),
             dtype='category'
             )
         )
@@ -268,13 +268,13 @@ def test_categorical_unique(num_elements):
 
 @pytest.mark.parametrize('num_elements', [10, 100, 1000])
 def test_categorical_value_counts(num_elements):
-    import string
+    from string import ascii_letters, digits
 
     # create categorical series
     np.random.seed(12)
     pd_cat = pd.Categorical(
         pd.Series(
-            np.random.choice(list(string.ascii_letters), num_elements),
+            np.random.choice(list(ascii_letters + digits), num_elements),
             dtype='category'
             )
         )
@@ -298,13 +298,13 @@ def test_categorical_value_counts(num_elements):
 
 @pytest.mark.parametrize('nelem', [20, 50, 100])
 def test_categorical_unique_count(nelem):
-    import string
+    from string import ascii_letters, digits
 
     # create categorical series
     np.random.seed(12)
     pd_cat = pd.Categorical(
         pd.Series(
-            np.random.choice(list(string.ascii_letters + string.digits), nelem),
+            np.random.choice(list(ascii_letters + digits), nelem),
             dtype='category'
             )
         )

--- a/pygdf/tests/test_categorical.py
+++ b/pygdf/tests/test_categorical.py
@@ -247,7 +247,7 @@ def test_categorical_unique(num_elements):
     np.random.seed(12)
     pd_cat = pd.Categorical(
         pd.Series(np.random.choice(list(string.ascii_letters), num_elements), 
-            dtype="category")
+            dtype='category')
         )
 
     # gdf
@@ -272,7 +272,7 @@ def test_categorical_value_counts(num_elements):
     np.random.seed(12)
     pd_cat = pd.Categorical(
         pd.Series(np.random.choice(list(string.ascii_letters), num_elements), 
-            dtype="category")
+            dtype='category')
         )
 
     # gdf

--- a/pygdf/tests/test_categorical.py
+++ b/pygdf/tests/test_categorical.py
@@ -242,24 +242,26 @@ def test_cat_series_binop_error():
 @pytest.mark.parametrize('num_elements', [10, 100, 1000])
 def test_categorical_unique(num_elements):
     import string
-        
+
     # create categorical series
     np.random.seed(12)
     pd_cat = pd.Categorical(
-        pd.Series(np.random.choice(list(string.ascii_letters), num_elements), 
-            dtype='category')
+        pd.Series(
+            np.random.choice(list(string.ascii_letters), num_elements),
+            dtype='category'
+            )
         )
 
     # gdf
     gdf = DataFrame()
     gdf['a'] = Series.from_categorical(pd_cat)
     gdf_unique_sorted = np.sort(gdf['a'].unique())
-    
+
     # pandas
     pdf = pd.DataFrame()
     pdf['a'] = pd_cat
     pdf_unique_sorted = np.sort(pdf['a'].unique())
-    
+
     # verify
     np.testing.assert_array_equal(pdf_unique_sorted, gdf_unique_sorted)
 
@@ -267,26 +269,28 @@ def test_categorical_unique(num_elements):
 @pytest.mark.parametrize('num_elements', [10, 100, 1000])
 def test_categorical_value_counts(num_elements):
     import string
-    
+
     # create categorical series
     np.random.seed(12)
     pd_cat = pd.Categorical(
-        pd.Series(np.random.choice(list(string.ascii_letters), num_elements), 
-            dtype='category')
+        pd.Series(
+            np.random.choice(list(string.ascii_letters), num_elements),
+            dtype='category'
+            )
         )
 
     # gdf
     gdf = DataFrame()
     gdf['a'] = Series.from_categorical(pd_cat)
     gdf_value_counts = gdf['a'].value_counts()
-    
+
     # pandas
     pdf = pd.DataFrame()
     pdf['a'] = pd_cat
     pdf_value_counts = pdf['a'].value_counts()
-    
+
     # verify
     pandas_dict = pdf_value_counts.to_dict()
     gdf_dict = gdf_value_counts.to_pandas().to_dict()
-    
+
     assert pandas_dict == gdf_dict

--- a/pygdf/tests/test_categorical.py
+++ b/pygdf/tests/test_categorical.py
@@ -297,7 +297,7 @@ def test_categorical_value_counts(num_elements):
 
 
 @pytest.mark.parametrize('nelem', [20, 50, 100])
-def test_categorical_unique_counts(nelem):
+def test_categorical_unique_count(nelem):
     import string
 
     # create categorical series
@@ -305,7 +305,7 @@ def test_categorical_unique_counts(nelem):
     pd_cat = pd.Categorical(
         pd.Series(
             np.random.choice(list(string.ascii_letters + string.digits), nelem),
-            dtype="category"
+            dtype='category'
             )
         )
 

--- a/pygdf/tests/test_categorical.py
+++ b/pygdf/tests/test_categorical.py
@@ -294,3 +294,30 @@ def test_categorical_value_counts(num_elements):
     gdf_dict = gdf_value_counts.to_pandas().to_dict()
 
     assert pandas_dict == gdf_dict
+
+
+@pytest.mark.parametrize('nelem', [20, 50, 100])
+def test_categorical_unique_counts(nelem):
+    import string
+
+    # create categorical series
+    np.random.seed(12)
+    pd_cat = pd.Categorical(
+        pd.Series(
+            np.random.choice(list(string.ascii_letters + string.digits), nelem),
+            dtype="category"
+            )
+        )
+
+    # gdf
+    gdf = DataFrame()
+    gdf['a'] = Series.from_categorical(pd_cat)
+    gdf_unique_count = gdf['a'].unique_count()
+
+    # pandas
+    pdf = pd.DataFrame()
+    pdf['a'] = pd_cat
+    pdf_unique = pdf['a'].unique()
+
+    # verify
+    assert gdf_unique_count == len(pdf_unique)


### PR DESCRIPTION
This PR adds unit tests for `pygdf.Series` methods `.unique`, `.unique_count`, and `value_counts` for categorical data. As implemented, both `unique` and `value_counts` in `pygdf` sort differently than the equivalent `pd.Series` methods. If we want to enforce identical ordering, then the tests will need to shift. As written currently, the tests for `value_counts` require result correctness, but not result ordering.

This PR closes #167 .