### PR TITLE
[REVIEW] Feature/reflected ops

### DIFF
--- a/pygdf/series.py
+++ b/pygdf/series.py
@@ -288,12 +288,7 @@ class Series(object):
         return self._binaryop(other, 'sub')
 
     def __rsub__(self, other):
-        """test"""
-
-        # return self.__sub__(other)
-        if isinstance(other, (int)):
-            other = Series(other)
-        return other.__sub__(self)
+        return self.__sub__(other)
 
     def __mul__(self, other):
         return self._binaryop(other, 'mul')

--- a/pygdf/series.py
+++ b/pygdf/series.py
@@ -288,7 +288,13 @@ class Series(object):
         return self._binaryop(other, 'sub')
 
     def __rsub__(self, other):
-        return self.__sub__(other)
+        if isinstance(other, (int, float,
+                              np.int32, np.int64,
+                              np.float32, np.float64)):
+            empty = np.empty(len(self))
+            empty.fill(other)
+            other = Series(empty)
+        return other.__sub__(self)
 
     def __mul__(self, other):
         return self._binaryop(other, 'mul')
@@ -300,13 +306,25 @@ class Series(object):
         return self._binaryop(other, 'floordiv')
 
     def __rfloordiv__(self, other):
-        return self.__floordiv__(other)
+        if isinstance(other, (int, float,
+                              np.int32, np.int64,
+                              np.float32, np.float64)):
+            empty = np.empty(len(self))
+            empty.fill(other)
+            other = Series(empty)
+        return other.__floordiv__(self)
 
     def __truediv__(self, other):
         return self._binaryop(other, 'truediv')
 
     def __rtruediv__(self, other):
-        return self.__truediv__(other)
+        if isinstance(other, (int, float,
+                              np.int32, np.int64,
+                              np.float32, np.float64)):
+            empty = np.empty(len(self))
+            empty.fill(other)
+            other = Series(empty)
+        return other.__truediv__(self)
 
     __div__ = __truediv__
 

--- a/pygdf/series.py
+++ b/pygdf/series.py
@@ -291,7 +291,9 @@ class Series(object):
         """test"""
 
         # return self.__sub__(other)
-        return other - self
+        if isinstance(other, (int)):
+            other = Series(other)
+        return other.__sub__(self)
 
     def __mul__(self, other):
         return self._binaryop(other, 'mul')

--- a/pygdf/series.py
+++ b/pygdf/series.py
@@ -288,6 +288,7 @@ class Series(object):
         return self._binaryop(other, 'sub')
 
     def __rsub__(self, other):
+        """test"""
         print(self, other)
         return self.__sub__(other)
 

--- a/pygdf/series.py
+++ b/pygdf/series.py
@@ -269,6 +269,16 @@ class Series(object):
         outcol = self._column.binary_operator(fn, other._column)
         return self._copy_construct(data=outcol)
 
+    def _rbinaryop(self, other, fn):
+        """
+        Internal util to call a binary operator *fn* on operands *self*
+        and *other* for reflected operations.  Return the output Series.
+        The output dtype is determined by the input operands.
+        """
+        other = self._normalize_binop_value(other)
+        outcol = other._column.binary_operator(fn, self._column)
+        return self._copy_construct(data=outcol)
+
     def _unaryop(self, fn):
         """
         Internal util to call a unary operator *fn* on operands *self*.
@@ -282,37 +292,31 @@ class Series(object):
         return self._binaryop(other, 'add')
 
     def __radd__(self, other):
-        return self.__add__(other)
+        return self._rbinaryop(other, 'add')
 
     def __sub__(self, other):
         return self._binaryop(other, 'sub')
 
     def __rsub__(self, other):
-        other = self._normalize_binop_value(other)
-        outcol = other._column.binary_operator('sub', self._column)
-        return self._copy_construct(data=outcol)
+        return self._rbinaryop(other, 'sub')
 
     def __mul__(self, other):
         return self._binaryop(other, 'mul')
 
     def __rmul__(self, other):
-        return self.__mul__(other)
+        return self._rbinaryop(other, 'mul')
 
     def __floordiv__(self, other):
         return self._binaryop(other, 'floordiv')
 
     def __rfloordiv__(self, other):
-        other = self._normalize_binop_value(other)
-        outcol = other._column.binary_operator('floordiv', self._column)
-        return self._copy_construct(data=outcol)
+        return self._rbinaryop(other, 'floordiv')
 
     def __truediv__(self, other):
         return self._binaryop(other, 'truediv')
 
     def __rtruediv__(self, other):
-        other = self._normalize_binop_value(other)
-        outcol = other._column.binary_operator('truediv', self._column)
-        return self._copy_construct(data=outcol)
+        return self._rbinaryop(other, 'truediv')
 
     __div__ = __truediv__
 

--- a/pygdf/series.py
+++ b/pygdf/series.py
@@ -299,8 +299,14 @@ class Series(object):
     def __floordiv__(self, other):
         return self._binaryop(other, 'floordiv')
 
+    def __rfloordiv__(self, other):
+        return self.__floordiv__(other)
+
     def __truediv__(self, other):
         return self._binaryop(other, 'truediv')
+
+    def __rtruediv__(self, other):
+        return self.__truediv__(other)
 
     __div__ = __truediv__
 

--- a/pygdf/series.py
+++ b/pygdf/series.py
@@ -288,8 +288,8 @@ class Series(object):
         return self._binaryop(other, 'sub')
 
     def __rsub__(self, other):
-        # return self.__sub__(other)
-        return other - self
+        print(self, other)
+        return self.__sub__(other)
 
     def __mul__(self, other):
         return self._binaryop(other, 'mul')

--- a/pygdf/series.py
+++ b/pygdf/series.py
@@ -281,6 +281,9 @@ class Series(object):
     def __add__(self, other):
         return self._binaryop(other, 'add')
 
+    def __radd__(self, other):
+        return self.__add__(other)
+
     def __sub__(self, other):
         return self._binaryop(other, 'sub')
 

--- a/pygdf/series.py
+++ b/pygdf/series.py
@@ -287,8 +287,14 @@ class Series(object):
     def __sub__(self, other):
         return self._binaryop(other, 'sub')
 
+    def __rsub__(self, other):
+        return self.__sub__(other)
+
     def __mul__(self, other):
         return self._binaryop(other, 'mul')
+
+    def __rmul__(self, other):
+        return self.__mul__(other)
 
     def __floordiv__(self, other):
         return self._binaryop(other, 'floordiv')

--- a/pygdf/series.py
+++ b/pygdf/series.py
@@ -289,8 +289,9 @@ class Series(object):
 
     def __rsub__(self, other):
         """test"""
-        print(self, other)
-        return self.__sub__(other)
+
+        # return self.__sub__(other)
+        return other - self
 
     def __mul__(self, other):
         return self._binaryop(other, 'mul')

--- a/pygdf/series.py
+++ b/pygdf/series.py
@@ -288,13 +288,9 @@ class Series(object):
         return self._binaryop(other, 'sub')
 
     def __rsub__(self, other):
-        if isinstance(other, (int, float,
-                              np.int32, np.int64,
-                              np.float32, np.float64)):
-            empty = np.empty(len(self))
-            empty.fill(other)
-            other = Series(empty)
-        return other.__sub__(self)
+        other = self._normalize_binop_value(other)
+        outcol = other._column.binary_operator('sub', self._column)
+        return self._copy_construct(data=outcol)
 
     def __mul__(self, other):
         return self._binaryop(other, 'mul')
@@ -306,25 +302,17 @@ class Series(object):
         return self._binaryop(other, 'floordiv')
 
     def __rfloordiv__(self, other):
-        if isinstance(other, (int, float,
-                              np.int32, np.int64,
-                              np.float32, np.float64)):
-            empty = np.empty(len(self))
-            empty.fill(other)
-            other = Series(empty)
-        return other.__floordiv__(self)
+        other = self._normalize_binop_value(other)
+        outcol = other._column.binary_operator('floordiv', self._column)
+        return self._copy_construct(data=outcol)
 
     def __truediv__(self, other):
         return self._binaryop(other, 'truediv')
 
     def __rtruediv__(self, other):
-        if isinstance(other, (int, float,
-                              np.int32, np.int64,
-                              np.float32, np.float64)):
-            empty = np.empty(len(self))
-            empty.fill(other)
-            other = Series(empty)
-        return other.__truediv__(self)
+        other = self._normalize_binop_value(other)
+        outcol = other._column.binary_operator('truediv', self._column)
+        return self._copy_construct(data=outcol)
 
     __div__ = __truediv__
 

--- a/pygdf/series.py
+++ b/pygdf/series.py
@@ -288,7 +288,8 @@ class Series(object):
         return self._binaryop(other, 'sub')
 
     def __rsub__(self, other):
-        return self.__sub__(other)
+        # return self.__sub__(other)
+        return other - self
 
     def __mul__(self, other):
         return self._binaryop(other, 'mul')

--- a/pygdf/tests/test_binops.py
+++ b/pygdf/tests/test_binops.py
@@ -140,7 +140,7 @@ def test_series_cmpop_mixed_dtype(cmpop, lhs_dtype, rhs_dtype):
                                   cmpop(lhs, rhs))
 
 
-reflected_ops = [
+_reflected_ops = [
     lambda x: 1 + x,
     lambda x: 1 * x,
     lambda x: 1 - x,
@@ -149,7 +149,7 @@ reflected_ops = [
 ]
 
 
-@pytest.mark.parametrize('func, dtype', list(product(reflected_ops, _dtypes)))
+@pytest.mark.parametrize('func, dtype', list(product(_reflected_ops, _dtypes)))
 def test_reflected_ops_scalar(func, dtype):
     import pandas as pd
 

--- a/pygdf/tests/test_binops.py
+++ b/pygdf/tests/test_binops.py
@@ -156,7 +156,7 @@ _noncommut_ops = [
 def test_commutative_reflected_op_scalar(func, dtype):
     import pandas as pd
 
-    # create categorical series
+    # create random series
     np.random.seed(12)
     random_series = pd.Series(np.random.sample(100), dtype=dtype)
 

--- a/pygdf/tests/test_binops.py
+++ b/pygdf/tests/test_binops.py
@@ -144,7 +144,6 @@ _reflected_ops = [
     lambda x: 1 + x,
     lambda x: 2 * x,
     lambda x: 2 - x,
-    lambda x: 2 / x,
     lambda x: 2 // x,
 ]
 

--- a/pygdf/tests/test_binops.py
+++ b/pygdf/tests/test_binops.py
@@ -155,7 +155,7 @@ def test_reflected_ops_scalar(func, dtype):
 
     # create random series
     np.random.seed(12)
-    random_series = pd.Series(np.random.sample(100), dtype=dtype)
+    random_series = pd.Series(np.random.sample(100) + 10, dtype=dtype)
 
     # gpu series
     gs = Series(random_series)

--- a/pygdf/tests/test_binops.py
+++ b/pygdf/tests/test_binops.py
@@ -142,10 +142,10 @@ def test_series_cmpop_mixed_dtype(cmpop, lhs_dtype, rhs_dtype):
 
 _reflected_ops = [
     lambda x: 1 + x,
-    lambda x: 1 * x,
-    lambda x: 1 - x,
-    lambda x: 1 / x,
-    lambda x: 1 // x,
+    lambda x: 2 * x,
+    lambda x: 2 - x,
+    lambda x: 2 / x,
+    lambda x: 2 // x,
 ]
 
 

--- a/pygdf/tests/test_binops.py
+++ b/pygdf/tests/test_binops.py
@@ -138,3 +138,39 @@ def test_series_cmpop_mixed_dtype(cmpop, lhs_dtype, rhs_dtype):
 
     np.testing.assert_array_equal(cmpop(Series(lhs), Series(rhs)).to_array(),
                                   cmpop(lhs, rhs))
+
+
+_commut_ops = [
+    lambda x: 1 + x,
+    lambda x: 1 * x,
+]
+
+_noncommut_ops = [
+    lambda x: 1 - x,
+    lambda x: 1 / x,
+    lambda x: 1 // x,
+]
+
+
+@pytest.mark.parametrize('func, dtype', list(product(_commut_ops, _dtypes)))
+def test_commutative_reflected_op_scalar(func, dtype):
+    import pandas as pd
+
+    # create categorical series
+    np.random.seed(12)
+    random_series = pd.Series(np.random.sample(100), dtype=dtype)
+
+    # gpu series
+    gs = Series(random_series)
+    gs_result = func(gs)
+
+    # pandas
+    ps_result = func(random_series)
+
+    # verify
+    np.testing.assert_array_equal(ps_result, gs_result)
+
+
+@pytest.mark.parametrize('func, dtype', list(product(_noncommut_ops, _dtypes)))
+def test_noncommutative_reflected_ops(func, dtype):
+    pass

--- a/pygdf/tests/test_binops.py
+++ b/pygdf/tests/test_binops.py
@@ -140,20 +140,17 @@ def test_series_cmpop_mixed_dtype(cmpop, lhs_dtype, rhs_dtype):
                                   cmpop(lhs, rhs))
 
 
-_commut_ops = [
+reflected_ops = [
     lambda x: 1 + x,
     lambda x: 1 * x,
-]
-
-_noncommut_ops = [
     lambda x: 1 - x,
     lambda x: 1 / x,
     lambda x: 1 // x,
 ]
 
 
-@pytest.mark.parametrize('func, dtype', list(product(_commut_ops, _dtypes)))
-def test_commutative_reflected_op_scalar(func, dtype):
+@pytest.mark.parametrize('func, dtype', list(product(reflected_ops, _dtypes)))
+def test_reflected_ops_scalar(func, dtype):
     import pandas as pd
 
     # create random series
@@ -168,9 +165,4 @@ def test_commutative_reflected_op_scalar(func, dtype):
     ps_result = func(random_series)
 
     # verify
-    np.testing.assert_array_equal(ps_result, gs_result)
-
-
-@pytest.mark.parametrize('func, dtype', list(product(_noncommut_ops, _dtypes)))
-def test_noncommutative_reflected_ops(func, dtype):
-    pass
+    np.testing.assert_allclose(ps_result, gs_result)


### PR DESCRIPTION
This PR adds reflected operations for addition, multiplication, subtraction, true division, and floor division (and associated unit tests). [Reflected operations](https://docs.python.org/3.2/reference/datamodel.html#emulating-numeric-types) implement binary operations and are used when the left operand does not support the operation and is of a different type.

Currently, `__radd__` and `__rmul__` are implemented and passing tests.

Initial placeholder versions of `__rsub__`, `__rtruediv`, and `__rfloordiv__` are implemented (the non-commutative operations). Instead of performing `left operand - right operand`, `left operand /  right operand`, etc., they perform `right operand - left operand`.

Implementing the non-commutative operations may require defining and populating a `Series` of matching dimensions with each value being the scalar. A naive implementation that doesn't match the dimensions such as:
```
def __rsub__(self, other):
    if isinstance(other, (np.int32, np.float32, ...)):
        other = Series(other)
    return other.__sub__(self)
````
will result in a `GDF_COLUMN_SIZE_MISMATCH` error when doing binary operations on Series of different sizes. 

There's likely an approach leveraging some of the column ops like `column_empty_like` and `fillna`. I wiill test it and profile it, but I'm just not sure if it's optimal. I am happy to defer to @kkraus14, @scopatz, and others with more knowledge on what the right approach is for these non-commutative operations. 

This PR closes #208. If/when this PR is merged, squash/merge may be the best idea as the commit history is a bit circular.