### PR TITLE
Fix timezone issue when converting from datetime object into datetime64

### DIFF
--- a/pygdf/datetime.py
+++ b/pygdf/datetime.py
@@ -82,15 +82,10 @@ class DatetimeColumn(columnops.TypedColumnBase):
         return out
 
     def normalize_binop_value(self, other):
-
         if isinstance(other, dt.datetime):
-            other = time.mktime(other.timetuple())
-            ary = utils.scalar_broadcast_to(
-                int(other * self._inverse_precision),
-                shape=len(self),
-                dtype=self._npdatetime64_dtype
-            )
-        elif isinstance(other, pd.Timestamp):
+            other = np.datetime64(other)
+
+        if isinstance(other, pd.Timestamp):
             ary = utils.scalar_broadcast_to(
                 other.value * self._pandas_conversion_factor,
                 shape=len(self),

--- a/pygdf/datetime.py
+++ b/pygdf/datetime.py
@@ -1,5 +1,4 @@
 import datetime as dt
-import time
 
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
Fixes a failure I observed in pygdf/tests/test_datetime.py::test_issue_165.  `time.mktime` is assuming the input to be in local timezone and it is adjusting it to UTC.  The patch just let numpy do the conversion.
