### PR TITLE
[REVIEW] Fix (de)serialization error for DatetimeColumn

### DIFF
--- a/pygdf/serialize.py
+++ b/pygdf/serialize.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from types import MethodType
 
 # A flag to allow dask_gdf to detect and warn if
 # IPC serialization is unavailable
@@ -21,12 +22,18 @@ else:
         """
         _dp.register_serialization(cls, _serialize, _deserialize)
 
+    def has_context_keyword(meth):
+        if isinstance(meth, MethodType):
+            return has_keyword(meth.__func__, 'context')
+        else:
+            return has_keyword(meth, 'context')
+
     def _serialize(df, context=None):
         def do_serialize(x):
             return _dp.serialize(x, context=context)
 
-        def call_with_context(meth, x, *args):
-            if has_keyword(meth, 'context'):
+        def call_with_context(meth, x):
+            if has_context_keyword(meth):
                 return meth(x, context=context)
             else:
                 return meth(x)

--- a/pygdf/tests/test_serialize.py
+++ b/pygdf/tests/test_serialize.py
@@ -138,12 +138,13 @@ def _load_ipc(header, frames, result_queue):
 
 @require_distributed
 def test_serialize_datetime():
+    # Make frame with datetime column
     df = pd.DataFrame({'x': np.random.randint(0, 5, size=20),
                        'y': np.random.normal(size=20)})
-    ts = np.arange(0, len(df), dtype=np.dtype('datetime64[ns]'))
+    ts = np.arange(0, len(df), dtype=np.dtype('datetime64[ms]'))
     df['timestamp'] = ts
-    out = pygdf.DataFrame.from_pandas(df)
-
-    recreated = deserialize(*serialize(out))
+    gdf = pygdf.DataFrame.from_pandas(df)
+    # (De)serialize roundtrip
+    recreated = deserialize(*serialize(gdf))
+    # Check
     pd.util.testing.assert_frame_equal(recreated.to_pandas(), df)
-

--- a/pygdf/tests/test_serialize.py
+++ b/pygdf/tests/test_serialize.py
@@ -134,3 +134,16 @@ def _load_ipc(header, frames, result_queue):
         result_queue.put(out)
     except Exception as e:
         result_queue.put(e)
+
+
+@require_distributed
+def test_serialize_datetime():
+    df = pd.DataFrame({'x': np.random.randint(0, 5, size=20),
+                       'y': np.random.normal(size=20)})
+    ts = np.arange(0, len(df), dtype=np.dtype('datetime64[ns]'))
+    df['timestamp'] = ts
+    out = pygdf.DataFrame.from_pandas(df)
+
+    recreated = deserialize(*serialize(out))
+    pd.util.testing.assert_frame_equal(recreated.to_pandas(), df)
+


### PR DESCRIPTION
This is revealed in a test in `dask_gdf` join that `DatetimeColumn` is unable to be serialized and deserialized.  `distributed` has silenced any error due to custom serialization, causing it to be difficult to understand the actual cause.  In addition, there is a failure on master for one of the serialization test because `Series` is unhashable.  The error is fixed here.