### PR TITLE
[REVIEW] Use sets to avoid differently ordered columns

### DIFF
--- a/pygdf/dataframe.py
+++ b/pygdf/dataframe.py
@@ -426,8 +426,8 @@ class DataFrame(object):
 
     @classmethod
     def _concat(cls, objs, ignore_index=False):
-        if len(set(o.columns for o in objs)) != 1:
-            what = set(o.columns for o in objs)
+        if len(set([tuple(set(o.columns)) for o in objs])) != 1:
+            what = set([tuple(set(o.columns)) for o in objs])
             raise ValueError('columns mismatch: {}'.format(what))
         objs = [o for o in objs]
         if ignore_index:

--- a/pygdf/dataframe.py
+++ b/pygdf/dataframe.py
@@ -426,8 +426,8 @@ class DataFrame(object):
 
     @classmethod
     def _concat(cls, objs, ignore_index=False):
-        if len(set([tuple(set(o.columns)) for o in objs])) != 1:
-            what = set([tuple(set(o.columns)) for o in objs])
+        if len(set(sorted(o.columns) for o in objs)) != 1:
+            what = set(sorted(o.columns) for o in objs)
             raise ValueError('columns mismatch: {}'.format(what))
         objs = [o for o in objs]
         if ignore_index:

--- a/pygdf/dataframe.py
+++ b/pygdf/dataframe.py
@@ -426,8 +426,8 @@ class DataFrame(object):
 
     @classmethod
     def _concat(cls, objs, ignore_index=False):
-        if len(set(sorted(o.columns) for o in objs)) != 1:
-            what = set(sorted(o.columns) for o in objs)
+        if len(set(frozenset(o.columns) for o in objs)) != 1:
+            what = set(frozenset(o.columns) for o in objs)
             raise ValueError('columns mismatch: {}'.format(what))
         objs = [o for o in objs]
         if ignore_index:

--- a/pygdf/tests/test_multi.py
+++ b/pygdf/tests/test_multi.py
@@ -86,7 +86,7 @@ def test_concat_misordered_columns():
     gdf2 = gdf2[['z', 'x', 'y']]
     df2 = df2[['z', 'x', 'y']]
 
-    res = gd.concat([gd, gdf2]).to_pandas()
+    res = gd.concat([gdf, gdf2]).to_pandas()
     sol = pd.concat([df, df2])
 
     pd.util.testing.assert_frame_equal(res, sol, check_names=False)

--- a/pygdf/tests/test_multi.py
+++ b/pygdf/tests/test_multi.py
@@ -79,3 +79,14 @@ def test_concat_errors():
     # Mismatched columns
     with pytest.raises(ValueError):
         gd.concat([gdf, gdf2])
+
+
+def test_concat_misordered_columns():
+    df, df2, gdf, gdf2 = make_frames(False)
+    gdf2 = gdf2[['z', 'x', 'y']]
+    df2 = df2[['z', 'x', 'y']]
+
+    res = gd.concat([gd, gdf2]).to_pandas()
+    sol = pd.concat([df, df2])
+
+    pd.util.testing.assert_frame_equal(res, sol, check_names=False)


### PR DESCRIPTION
Handle situations like the following:

```python
gdf1 = DataFrame()
gdf1['a'] = [1,2,3]
gdf1['b'] = [4,5,6]

gdf2 = DataFrame()
gdf2['b'] = [1,2,3]
gdf2['a'] = [4,5,6]

gdf = pygdf.concat([gdf1, gdf2])
```
