### PR TITLE
[REVIEW] Enhance scalar_broadcast_to perf

### DIFF
--- a/pygdf/cudautils.py
+++ b/pygdf/cudautils.py
@@ -170,6 +170,12 @@ def gpu_fill_value(data, value):
         data[tid] = value
 
 
+def fill_value(arr, value):
+    """Fill *arr* with value
+    """
+    gpu_fill_value.forall(arr.size)(arr, value)
+
+
 @cuda.jit
 def gpu_expand_mask_bits(bits, out):
     """Expand each bits in bitmask *bits* into an element in out.

--- a/pygdf/utils.py
+++ b/pygdf/utils.py
@@ -48,12 +48,13 @@ def require_writeable_array(arr):
 
 
 def scalar_broadcast_to(scalar, shape, dtype):
+    from .cudautils import fill_value
+
     if not isinstance(shape, tuple):
         shape = (shape,)
-    arr = np.broadcast_to(np.asarray(scalar, dtype=dtype), shape=shape)
-    # FIXME: this is wasteful, but numba can't slice 0-strided array
-    arr = np.ascontiguousarray(np.asarray(arr))
-    return cuda.to_device(require_writeable_array(arr))
+    da = cuda.device_array(shape, dtype=dtype)
+    fill_value(da, scalar)
+    return da
 
 
 def normalize_index(index, size, doraise=True):


### PR DESCRIPTION
Avoid doing work on the CPU side for `scalar_broadcast_to()`.  This increases the performance of the function.  

```python
df = pygdf.DataFrame()
df['a'] = np.arange(5 * 1000000, dtype=np.float64)
%timeit df.a + 3
```
went from 14ms to 3.7ms.