### PR TITLE
[REVIEW] Change count_nonzero_mask to use libgdf 

### DIFF
--- a/pygdf/_gdf.py
+++ b/pygdf/_gdf.py
@@ -381,8 +381,8 @@ def count_nonzero_mask(mask, size):
     nnz = ffi.new('int*')
     nnz[0] = 0
     mask_ptr, addr = unwrap_mask(mask)
+
     if addr != ffi.NULL:
         libgdf.gdf_count_nonzero_mask(mask_ptr, size, nnz)
-    else:
-        nnz[0] = 0
+
     return nnz[0]

--- a/pygdf/_gdf.py
+++ b/pygdf/_gdf.py
@@ -13,12 +13,19 @@ from numba import cuda
 
 from libgdf_cffi import ffi, libgdf
 from . import cudautils
+from .utils import mask_bitsize
 
 
 def unwrap_devary(devary):
     ptrval = devary.device_ctypes_pointer.value
     ptrval = ptrval or ffi.NULL   # replace None with NULL
     return ffi.cast('void*', ptrval)
+
+
+def unwrap_mask(devary):
+    ptrval = devary.device_ctypes_pointer.value
+    ptrval = ptrval or ffi.NULL   # replace None with NULL
+    return ffi.cast('gdf_valid_type*', ptrval), ptrval
 
 
 def columnview_from_devary(devary, dtype=None):
@@ -106,7 +113,7 @@ def apply_unaryop(unaop, inp, out):
 def apply_mask_and(col, mask, out):
     args = (col.cffi_view, mask.cffi_view, out.cffi_view)
     libgdf.gdf_validity_and(*args)
-    nnz = cudautils.count_nonzero_mask(out.mask.mem, size=len(out))
+    nnz = count_nonzero_mask(out.mask.mem, size=len(out))
     return len(out) - nnz
 
 
@@ -367,3 +374,15 @@ def hash_partition(input_columns, key_indices, nparts, output_columns):
 
     offsets = list(offsets)
     return offsets
+
+
+def count_nonzero_mask(mask, size):
+    assert mask.size * mask_bitsize >= size
+    nnz = ffi.new('int*')
+    nnz[0] = 0
+    mask_ptr, addr = unwrap_mask(mask)
+    if addr != ffi.NULL:
+        libgdf.gdf_count_nonzero_mask(mask_ptr, size, nnz)
+    else:
+        nnz[0] = 0
+    return nnz[0]

--- a/pygdf/column.py
+++ b/pygdf/column.py
@@ -95,8 +95,8 @@ class Column(object):
         assert null_count is None or null_count >= 0
         if null_count is None:
             if self._mask is not None:
-                nnz = cudautils.count_nonzero_mask(self._mask.mem,
-                                                   size=len(self))
+                nnz = _gdf.count_nonzero_mask(self._mask.mem,
+                                              size=len(self))
                 null_count = len(self) - nnz
                 if null_count == 0:
                     self._mask = None

--- a/pygdf/cudautils.py
+++ b/pygdf/cudautils.py
@@ -233,13 +233,6 @@ def prefixsum(vals):
     return slots
 
 
-def count_nonzero_mask(mask, size):
-    assert mask.size * mask_bitsize >= size
-    # TODO: this needs optimization
-    _, nnz = mask_assign_slot(size, mask)
-    return nnz
-
-
 def copy_to_dense(data, mask, out=None):
     """Copy *data* with validity bits in *mask* into *out*.
 


### PR DESCRIPTION
Changes to `_gdf.py` and `column.py` to change calls of `count_nonzero_mask` to use new libgdf implementation. Also delete existing `cudautils.py` existing one.

NOTE: it requires corresponding libgdf merge: https://github.com/gpuopenanalytics/libgdf/pull/147