### PR TITLE
[REVIEW] Fix datetime handling in CSV reader

### DIFF
--- a/pygdf/io.py
+++ b/pygdf/io.py
@@ -7,6 +7,8 @@ from .numerical import NumericalColumn
 from .dataframe import DataFrame
 from .datetime import DatetimeColumn
 
+import numpy as np
+
 
 def _wrap_string(text):
     if(text is None):
@@ -130,8 +132,8 @@ def read_csv(filepath, lineterminator='\n',
     outcols = []
     for i in range(csv_reader.num_cols_out):
         newcol = Column.from_cffi_view(out[i])
-        if(newcol.dtype == 'datetime64'):
-            outcols.append(newcol.view(DatetimeColumn, dtype='datetime64[s]'))
+        if(newcol.dtype == np.dtype('datetime64[ms]')):
+            outcols.append(newcol.view(DatetimeColumn, dtype='datetime64[ms]'))
         else:
             outcols.append(newcol.view(NumericalColumn, dtype=newcol.dtype))
 


### PR DESCRIPTION
Previous dtype check wasn't being compared properly and dtype was being set to seconds instead of milliseconds.