### PR TITLE
[REVIEW] Remove test warnings

### DIFF
--- a/pygdf/tests/test_csvreader.py
+++ b/pygdf/tests/test_csvreader.py
@@ -78,7 +78,7 @@ def test_csv_reader_numeric_data(dtype, nelem, tmpdir):
 
 def test_csv_reader_datetime_data(tmpdir):
 
-    fname = os.path.abspath('pygdf/tests/data/tmp_csvreader_file2.csv')
+    fname = tmpdir.mkdir("gdf_csv").join('tmp_csvreader_file2.csv')
 
     df = make_datetime_dataframe()
     df.to_csv(fname, index=False, header=False)
@@ -95,7 +95,7 @@ def test_csv_reader_datetime_data(tmpdir):
 
 def test_csv_reader_mixed_data_delimiter(tmpdir):
 
-    fname = os.path.abspath('pygdf/tests/data/tmp_csvreader_file3.csv')
+    fname = tmpdir.mkdir("gdf_csv").join('tmp_csvreader_file3.csv')
 
     df = make_numpy_mixed_dataframe()
     df.to_csv(fname, sep='|', index=False, header=False)

--- a/pygdf/tests/test_csvreader.py
+++ b/pygdf/tests/test_csvreader.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2018, NVIDIA CORPORATION.
 
-import os
 import pytest
 from collections import OrderedDict
 

--- a/pygdf/tests/test_query.py
+++ b/pygdf/tests/test_query.py
@@ -26,7 +26,7 @@ def test_query_parser(text, expect_args):
     info = queryutils.query_parser(text)
     fn = queryutils.query_builder(info, 'myfoo')
     assert callable(fn)
-    argspec = inspect.getargspec(fn)
+    argspec = inspect.getfullargspec(fn)
     assert tuple(argspec.args) == tuple(expect_args)
 
 

--- a/pygdf/tests/utils.py
+++ b/pygdf/tests/utils.py
@@ -11,7 +11,7 @@ def random_bitmask(size):
         number of bits
     """
     sz = utils.calc_chunk_size(size, utils.mask_bitsize)
-    data= np.random.randint(0, 255 + 1, size=sz) 
+    data = np.random.randint(0, 255 + 1, size=sz)
     return data.astype(utils.mask_dtype)
 
 

--- a/pygdf/tests/utils.py
+++ b/pygdf/tests/utils.py
@@ -11,7 +11,8 @@ def random_bitmask(size):
         number of bits
     """
     sz = utils.calc_chunk_size(size, utils.mask_bitsize)
-    data = np.random.random_integers(low=0, high=255, size=sz)
+    # data = np.random.random_integers(low=0, high=255, size=sz)
+    data= np.random.randint(0, 255 + 1, size=sz) 
     return data.astype(utils.mask_dtype)
 
 

--- a/pygdf/tests/utils.py
+++ b/pygdf/tests/utils.py
@@ -11,7 +11,6 @@ def random_bitmask(size):
         number of bits
     """
     sz = utils.calc_chunk_size(size, utils.mask_bitsize)
-    # data = np.random.random_integers(low=0, high=255, size=sz)
     data= np.random.randint(0, 255 + 1, size=sz) 
     return data.astype(utils.mask_dtype)
 


### PR DESCRIPTION
Changes to 2 call to deprecated functions in the tests to remove the associated warnings. Also moved generation of 2 temporary csv files to tmp folder. 