### PR TITLE
[REVIEW] Add pyarrow dep to fix Dockerfile and pygdf.readthedocs.io build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,10 +32,12 @@ ARG NUMBA_VERSION=0.40.0
 ARG NUMPY_VERSION=1.14.3
 # Locked to Pandas 0.20.3 by https://github.com/gpuopenanalytics/pygdf/issues/118
 ARG PANDAS_VERSION=0.20.3
+ARG PYARROW_VERSION=0.10.0
 RUN conda install -n gdf -y -c numba -c conda-forge -c defaults \
       numba=${NUMBA_VERSION} \
       numpy=${NUMPY_VERSION} \
       pandas=${PANDAS_VERSION} \
+      pyarrow=${PYARROW_VERSION} \
       cmake
 
 # LibGDF build/install

--- a/conda_environments/builddocs_py35.yml
+++ b/conda_environments/builddocs_py35.yml
@@ -11,6 +11,7 @@ dependencies:
 - libgdf_cffi=0.1.0a3.*
 - numba>=0.40.0dev
 - pandas=0.20.*
+- pyarrow=0.10.*
 - pip:
   - numpydoc
   - sphinx


### PR DESCRIPTION
* Add pyarrow=0.10.0 to conda deps for Dockerfile
* Add pyarrow=0.10.* to conda_environments/builddocs_py35.yml