### PR TITLE
[REVIEW] Update builddocs_py35.yml

### DIFF
--- a/conda_environments/builddocs_py35.yml
+++ b/conda_environments/builddocs_py35.yml
@@ -7,6 +7,7 @@ channels:
 dependencies:
 - python=3.5.*
 - pytest
+- cudatoolkit=9.2
 - libgdf=0.1.0a3.*
 - libgdf_cffi=0.1.0a3.*
 - numba>=0.40.0dev


### PR DESCRIPTION
Adding cudatoolkit-9.2 to the conda env used to build docs

This fixes a silent build failure which prevents the docs from actually including any API information